### PR TITLE
Load trained configuration during prediction

### DIFF
--- a/src/timesnet_forecast/utils/io.py
+++ b/src/timesnet_forecast/utils/io.py
@@ -4,6 +4,7 @@ from typing import Dict, List, Tuple, Literal
 import os
 import json
 import pickle
+import yaml
 import numpy as np
 import pandas as pd
 
@@ -21,6 +22,12 @@ def normalize_id(s: str) -> str:
     s2 = " ".join(str(s).split())  # collapse inner spaces
     s2 = s2.strip().replace(" ", "_")
     return s2
+
+
+def load_yaml(path: str) -> dict:
+    """Load YAML file into a dictionary."""
+    with open(path, "r", encoding="utf-8") as f:
+        return yaml.safe_load(f)
 
 
 def build_id_col(df: pd.DataFrame, id_col: str) -> pd.Series:


### PR DESCRIPTION
## Summary
- Ensure `predict.py` loads the saved training configuration (`config_used.yaml`) from the artifacts directory
- Merge CLI overrides while preserving model parameters for consistency
- Add YAML loader utility to support reading configs

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c59a20c2cc8328bd996566353df2dc