### PR TITLE
Respect mode-specific horizon in dataset indices

### DIFF
--- a/src/timesnet_forecast/data/dataset.py
+++ b/src/timesnet_forecast/data/dataset.py
@@ -25,9 +25,10 @@ class SlidingWindowDataset(Dataset):
         self.L = int(input_len)
         self.H = int(pred_len if mode == "direct" else 1)
         self.mode = mode
-        # Indices where a full (L,H) window fits
-        self.idxs = np.arange(self.T - self.L - (pred_len - 1))  # last valid start inclusive
-        # When pred_len=H, last usable start is T-L-H
+        # Indices where a full (L,H) window fits. self.H is the mode-specific
+        # output length, so the last valid start index is T - L - H.
+        self.idxs = np.arange(self.T - self.L - self.H + 1)
+        # In recursive mode self.H=1, so only the last H steps are excluded.
 
     def __len__(self) -> int:
         return int(len(self.idxs))


### PR DESCRIPTION
## Summary
- compute dataset start indices using mode-specific horizon `self.H`
- clarify comments about how `self.H` determines the last valid start index and recursive behavior

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c59cea880c83288afe038da70cff92