### PR TITLE
Support multi-step targets in recursive mode validation

### DIFF
--- a/src/timesnet_forecast/train.py
+++ b/src/timesnet_forecast/train.py
@@ -40,8 +40,12 @@ def _build_dataloader(
     prefetch_factor: int,
     shuffle: bool,
     drop_last: bool,
+    recursive_pred_len: int | None = None,
 ) -> DataLoader:
-    datasets = [SlidingWindowDataset(a, input_len, pred_len, mode) for a in arrays]
+    datasets = [
+        SlidingWindowDataset(a, input_len, pred_len, mode, recursive_pred_len)
+        for a in arrays
+    ]
     if len(datasets) == 1:
         ds = datasets[0]
     else:
@@ -179,7 +183,8 @@ def train_once(cfg: Dict) -> Tuple[float, Dict]:
         val_arrays, input_len, pred_len, mode, batch_size=cfg["train"]["batch_size"],
         num_workers=cfg["train"]["num_workers"], pin_memory=cfg["train"]["pin_memory"],
         persistent_workers=cfg["train"]["persistent_workers"], prefetch_factor=cfg["train"]["prefetch_factor"],
-        shuffle=False, drop_last=False
+        shuffle=False, drop_last=False,
+        recursive_pred_len=(pred_len if mode == "recursive" else None)
     )
 
     # --- model


### PR DESCRIPTION
## Summary
- Allow `SlidingWindowDataset` to override output length when in recursive mode
- Extend `_build_dataloader` and validation loader usage to supply override, yielding `[B, pred_len, N]` targets during validation
- Keep training dataloader targets at one step for recursive training

## Testing
- `pytest -q`
- `PYTHONPATH=src python - <<'PY' ...` (checks dataset target shapes)


------
https://chatgpt.com/codex/tasks/task_e_68c59ece173883288e9d81987e1ea9b3