### PR TITLE
Integrate Optuna pruning in tuning objective

### DIFF
--- a/src/timesnet_forecast/cli.py
+++ b/src/timesnet_forecast/cli.py
@@ -74,6 +74,8 @@ def cmd_tune(args: argparse.Namespace) -> None:
         # train_once returns best val_smape
         val_smape, _ = train_once(cfg)
         trial.report(val_smape, step=1)
+        if trial.should_prune():
+            raise optuna.TrialPruned()
         return val_smape
 
     study = optuna.create_study(direction="minimize", sampler=sampler, pruner=pruner)


### PR DESCRIPTION
## Summary
- Respect Optuna's pruning mechanism in tuning objective to stop unpromising trials early

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c5a32193108328b46452b9836e6910