### PR TITLE
Restrict channels_last conversion to 4D tensors

### DIFF
--- a/src/timesnet_forecast/utils/torch_opt.py
+++ b/src/timesnet_forecast/utils/torch_opt.py
@@ -18,7 +18,7 @@ def amp_autocast(enabled: bool):
 def maybe_channels_last(module: nn.Module, enabled: bool) -> nn.Module:
     if enabled:
         for p in module.parameters():
-            if p.is_floating_point():
+            if p.is_floating_point() and p.dim() == 4:
                 p.data = p.data.contiguous(memory_format=torch.channels_last)
         return module.to(memory_format=torch.channels_last)
     return module


### PR DESCRIPTION
## Summary
- Only convert 4D floating-point parameters to `channels_last` in `maybe_channels_last`

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c61a3292e88328ae2235896e6ae432