### PR TITLE
Disable channels_last by default

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -30,7 +30,7 @@ train:
   pin_memory: true
   persistent_workers: true
   prefetch_factor: 4
-  channels_last: true
+  channels_last: false
   val:
     strategy: "holdout"       # "holdout"|"rolling"
     holdout_days: 28


### PR DESCRIPTION
## Summary
- Set `train.channels_last` to `false` in default config to avoid failures for models not supporting 4D tensors

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c61a975d848328a2bd67100383efa0