### PR TITLE
Enable scalar output capture before torch.compile

### DIFF
--- a/src/timesnet_forecast/utils/torch_opt.py
+++ b/src/timesnet_forecast/utils/torch_opt.py
@@ -28,6 +28,7 @@ def maybe_compile(module: nn.Module, enabled: bool) -> nn.Module:
     if not enabled:
         return module
     try:
+        torch._dynamo.config.capture_scalar_outputs = True
         module = torch.compile(module, fullgraph=False)
     except Exception as e:
         # graceful fallback


### PR DESCRIPTION
## Summary
- ensure torch.compile captures scalar outputs by setting torch._dynamo.config.capture_scalar_outputs before compilation

## Testing
- `python -m py_compile src/timesnet_forecast/utils/torch_opt.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c61e848ab083288b908f5da82a10d2