### PR TITLE
Warm up TimesNet before optimizer setup

### DIFF
--- a/src/timesnet_forecast/train.py
+++ b/src/timesnet_forecast/train.py
@@ -199,6 +199,12 @@ def train_once(cfg: Dict) -> Tuple[float, Dict]:
         activation=str(cfg["model"]["activation"]),
         mode=mode,
     ).to(device)
+
+    # Lazily build model parameters so that downstream utilities see them
+    with torch.no_grad():
+        dummy = torch.zeros(1, input_len, len(ids), device=device)
+        model(dummy)
+
     if cfg["train"]["channels_last"]:
         model = maybe_channels_last(model, True)
     if cfg["train"]["compile"]:


### PR DESCRIPTION
## Summary
- Ensure TimesNet's parameters are initialized by running a dummy forward pass before building the optimizer.
- Apply `maybe_channels_last` and `maybe_compile` after the warm-up step.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6219e67808328a2030020f687aa21