### PR TITLE
Use cross-device torch.amp GradScaler

### DIFF
--- a/src/timesnet_forecast/train.py
+++ b/src/timesnet_forecast/train.py
@@ -212,7 +212,17 @@ def train_once(cfg: Dict) -> Tuple[float, Dict]:
 
     # --- optimizer / loss
     optim = torch.optim.AdamW(model.parameters(), lr=float(cfg["train"]["lr"]), weight_decay=float(cfg["train"]["weight_decay"]))
-    grad_scaler = torch.cuda.amp.GradScaler(enabled=(cfg["train"]["amp"] and device.type == "cuda"))
+    try:
+        grad_scaler = torch.amp.GradScaler(
+            device_type=device.type,
+            enabled=cfg["train"]["amp"] and device.type == "cuda",
+        )
+    except TypeError:
+        # For older PyTorch versions where ``device_type`` is unsupported.
+        grad_scaler = torch.amp.GradScaler(
+            device=device.type,
+            enabled=cfg["train"]["amp"] and device.type == "cuda",
+        )
     loss_fn = nn.MSELoss()
 
     # --- training loop


### PR DESCRIPTION
## Summary
- replace deprecated `torch.cuda.amp.GradScaler` with `torch.amp.GradScaler` using the runtime device type
- fall back to `device` argument for older PyTorch versions

## Testing
- `python -W error::FutureWarning -m src.timesnet_forecast.train --config configs/default.yaml --override train.epochs=1 train.batch_size=4 train.num_workers=1 train.prefetch_factor=2 train.device=cpu train.compile=false train.amp=true`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c62327126483289d71b1f413bfaf56