### PR TITLE
Validate holdout windows and adjust default split

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # Recursive-TimesNet
+
+- Validation holdout period must be at least `input_len + pred_len` days.

--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -33,7 +33,7 @@ train:
   channels_last: false
   val:
     strategy: "holdout"       # "holdout"|"rolling"
-    holdout_days: 28
+    holdout_days: 35          # must be >= model.input_len + model.pred_len
     rolling_folds: 3
     rolling_step_days: 14
 

--- a/src/timesnet_forecast/train.py
+++ b/src/timesnet_forecast/train.py
@@ -186,6 +186,8 @@ def train_once(cfg: Dict) -> Tuple[float, Dict]:
         shuffle=False, drop_last=False,
         recursive_pred_len=(pred_len if mode == "recursive" else None)
     )
+    if len(dl_val.dataset) == 0:
+        raise ValueError("Validation split has no windows; increase train.val.holdout_days or adjust model.input_len/pred_len.")
 
     # --- model
     model = TimesNet(


### PR DESCRIPTION
## Summary
- guard against empty validation sets by checking dataloader length
- ensure default holdout days cover input and prediction windows
- document required validation period length

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c626df8b448328891cf6bf6933e44f