### PR TITLE
Add weighted SMAPE evaluation with store weights

### DIFF
--- a/src/timesnet_forecast/utils/metrics.py
+++ b/src/timesnet_forecast/utils/metrics.py
@@ -4,15 +4,16 @@ from typing import Dict, List, Optional
 import numpy as np
 
 
-def smape_grouped(
+def wsmape_grouped(
     y_true: np.ndarray,
     y_pred: np.ndarray,
     ids: List[str],
     weights: Optional[Dict[str, float]] = None,
     eps: float = 1e-8,
 ) -> float:
-    """
-    Grouped SMAPE by store. Each id is "store_menu", store = split('_',1)[0].
+    """Weighted SMAPE grouped by store.
+
+    Each id is "store_menu", store = split('_',1)[0].
     Only dates with A_{t,i} != 0 included for item-level mean.
     If denom |A|+|P| == 0 at a timepoint, that point is skipped.
     If an item has no valid points, its SMAPE is 0 by definition here.


### PR DESCRIPTION
## Summary
- Rename grouped SMAPE metric to `wsmape_grouped` and clarify docstring
- Compute per-store weights and evaluate model using weighted SMAPE
- Log validation metric as `val_wsmape` for clarity

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c64cd35054832884591e50aac49d4c