### PR TITLE
Build lazy TimesNet layers before loading checkpoints

### DIFF
--- a/src/timesnet_forecast/predict.py
+++ b/src/timesnet_forecast/predict.py
@@ -83,6 +83,9 @@ def predict_once(cfg: Dict) -> str:
         activation=str(cfg_used["model"]["activation"]),
         mode=str(cfg_used["model"]["mode"]),
     ).to(device)
+    # Lazily constructed layers depend on number of series (channels).
+    dummy = torch.zeros(1, len(ids), 1, device=device)
+    model._build_lazy(N=len(ids), L=1, x=dummy)
     state = clean_state_dict(torch.load(model_file, map_location="cpu"))
     model.load_state_dict(state)
     model.eval()


### PR DESCRIPTION
## Summary
- Pre-build TimesNet's lazy layers using the known number of series before loading weights
- Load cleaned checkpoint and keep evaluation workflow unchanged

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c6521c3fa48328b3d68790fc3fbae5