### PR TITLE
Initialize TimesNet layers and fix pandas split

### DIFF
--- a/src/timesnet_forecast/predict.py
+++ b/src/timesnet_forecast/predict.py
@@ -83,6 +83,9 @@ def predict_once(cfg: Dict) -> str:
         activation=str(cfg_used["model"]["activation"]),
         mode=str(cfg_used["model"]["mode"]),
     ).to(device)
+    # Lazily constructed layers depend on number of series (channels).
+    dummy = torch.zeros(1, len(ids), 1, device=device)
+    model._build_lazy(N=len(ids), L=1, x=dummy)
     state = clean_state_dict(torch.load(model_file, map_location="cpu"))
     model.load_state_dict(state)
     model.eval()

--- a/src/timesnet_forecast/train.py
+++ b/src/timesnet_forecast/train.py
@@ -134,7 +134,7 @@ def train_once(cfg: Dict) -> Tuple[float, Dict]:
     df = pd.read_csv(train_path, encoding=enc)
     # compute store-level weights based on total target value
     df["_id_norm"] = io_utils.build_id_col(df, schema["id"])
-    df["_store"] = df["_id_norm"].str.split("_", 1).str[0]
+    df["_store"] = df["_id_norm"].str.split("_", n=1).str[0]
     store_weights = df.groupby("_store")[schema["target"]].sum().to_dict()
     wide = io_utils.pivot_long_to_wide(
         df, date_col=schema["date"], id_col=schema["id"], target_col=schema["target"],


### PR DESCRIPTION
## Summary
- Pre-build TimesNet's lazy layers using the known number of series before loading weights
- Load cleaned checkpoint and keep evaluation workflow unchanged
- Use keyword argument `n=1` when splitting normalized IDs to avoid pandas positional-argument error

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6521c3fa48328b3d68790fc3fbae5