### PR TITLE
Support date-based submission formatting

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -65,4 +65,5 @@ artifacts:
 
 submission:
   out_path: "outputs/submissions/submission.csv"
-  format: "row_key_menu"
+  format: "date_menu"          # predictions keyed by date instead of row_key
+  date_col: "영업일자"


### PR DESCRIPTION
## Summary
- index test forecasts by future calendar dates and combine across parts
- allow `format_submission` to match predictions using a configurable date column
- document date-based submission format in default config

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c662d9fee0832881facbc17142d9af