### PR TITLE
Handle invalid row keys in submission formatting

### DIFF
--- a/src/timesnet_forecast/utils/io.py
+++ b/src/timesnet_forecast/utils/io.py
@@ -8,6 +8,7 @@ import re
 import yaml
 import numpy as np
 import pandas as pd
+import logging
 
 
 def resolve_schema(cfg: dict) -> Dict[str, str]:
@@ -202,7 +203,13 @@ def format_submission(
     menu_cols = [c for c in out.columns if c != date_col]
     for i, row in out.iterrows():
         rk = row[date_col]
-        test_part, day_num = parse_row_key(rk)
+        try:
+            test_part, day_num = parse_row_key(rk)
+        except ValueError:
+            logging.warning(f"Invalid row key encountered: {rk}")
+            out.loc[i, menu_cols] = 0.0
+            out.loc[i, date_col] = pd.NaT
+            continue
         P = preds_by_test.get(test_part)
         if P is None or (day_num - 1) not in range(len(P)):
             out.loc[i, menu_cols] = 0.0

--- a/tests/test_format_submission.py
+++ b/tests/test_format_submission.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+import sys
+import pandas as pd
+
+# Ensure src path is available for imports
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from timesnet_forecast.utils.io import format_submission
+
+
+def test_format_submission_invalid_row_key():
+    sample_df = pd.DataFrame(
+        {
+            "date": ["TEST_A+Day 1", "BAD_KEY"],
+            "MENU_1": [0.0, 0.0],
+            "MENU_2": [0.0, 0.0],
+        }
+    )
+
+    pred_df = pd.DataFrame(
+        [[1.0, 2.0], [3.0, 4.0]],
+        index=pd.date_range("2023-01-01", periods=2, freq="D"),
+        columns=["MENU_1", "MENU_2"],
+    )
+    preds_by_test = {"TEST_A": pred_df}
+
+    out = format_submission(sample_df, preds_by_test, date_col="date")
+
+    # First row parsed successfully
+    assert out.loc[0, "date"] == pd.Timestamp("2023-01-01")
+    assert out.loc[0, "MENU_1"] == 1.0
+    assert out.loc[0, "MENU_2"] == 2.0
+
+    # Second row had invalid key and should be filled with defaults
+    assert pd.isna(out.loc[1, "date"])
+    assert out.loc[1, "MENU_1"] == 0.0
+    assert out.loc[1, "MENU_2"] == 0.0


### PR DESCRIPTION
## Summary
- guard `format_submission` against invalid row keys by logging and defaulting to NaT/0.0
- add regression test to ensure parsing failures don't crash

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c675b69b888328bf03344977de5ce3