### PR TITLE
Add row_key-based prediction aggregation and update submission format

### DIFF
--- a/src/timesnet_forecast/utils/io.py
+++ b/src/timesnet_forecast/utils/io.py
@@ -196,7 +196,7 @@ def parse_row_key(row_key: str) -> Tuple[str, int]:
 
 def format_submission(
     sample_df: pd.DataFrame,
-    preds_by_test: Dict[str, pd.DataFrame],
+    preds: pd.DataFrame,
     date_col: str,
 ) -> pd.DataFrame:
     out = sample_df.copy()
@@ -210,13 +210,13 @@ def format_submission(
             out.loc[i, menu_cols] = 0.0
             out.loc[i, date_col] = pd.NaT
             continue
-        P = preds_by_test.get(test_part)
-        if P is None or (day_num - 1) not in range(len(P)):
+        lookup_key = f"{test_part}+D{day_num}"
+        if lookup_key not in preds.index:
             out.loc[i, menu_cols] = 0.0
             out.loc[i, date_col] = pd.NaT
             continue
-        out.loc[i, date_col] = P.index[day_num - 1]
-        vals = P.iloc[day_num - 1]
+        out.loc[i, date_col] = preds.loc[lookup_key, "date"]
+        vals = preds.loc[lookup_key, menu_cols]
         out.loc[i, menu_cols] = vals.reindex(menu_cols).fillna(0.0).values
     out[date_col] = pd.to_datetime(out[date_col])
     return out

--- a/tests/test_format_submission.py
+++ b/tests/test_format_submission.py
@@ -22,9 +22,11 @@ def test_format_submission_invalid_row_key():
         index=pd.date_range("2023-01-01", periods=2, freq="D"),
         columns=["MENU_1", "MENU_2"],
     )
-    preds_by_test = {"TEST_A": pred_df}
+    pred_df["date"] = pred_df.index
+    pred_df["row_key"] = ["TEST_A+D1", "TEST_A+D2"]
+    preds = pred_df.set_index("row_key")
 
-    out = format_submission(sample_df, preds_by_test, date_col="date")
+    out = format_submission(sample_df, preds, date_col="date")
 
     # First row parsed successfully
     assert out.loc[0, "date"] == pd.Timestamp("2023-01-01")


### PR DESCRIPTION
## Summary
- Collect per-test predictions with `row_key` identifiers and concatenate into a single DataFrame
- Replace `preds_by_test` dict-based submission formatting with `preds` DataFrame lookup
- Update tests for new row_key-based submission interface

## Testing
- `pytest -q >/tmp/pytest.log && cat /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68c6796f16308328abb04789beaf1aff