### PR TITLE
Refactor submission formatting with normalized series names

### DIFF
--- a/tests/test_format_submission.py
+++ b/tests/test_format_submission.py
@@ -11,29 +11,27 @@ from timesnet_forecast.utils.io import format_submission
 def test_format_submission_invalid_row_key():
     sample_df = pd.DataFrame(
         {
-            "date": ["TEST_A+Day 1", "BAD_KEY"],
-            "MENU_1": [0.0, 0.0],
-            "MENU_2": [0.0, 0.0],
+            "row_key": ["TEST_A+Day 1", "BAD_KEY"],
+            "MENU 1": [0.0, 0.0],
+            "MENU 2": [0.0, 0.0],
         }
     )
 
-    pred_df = pd.DataFrame(
+    preds = pd.DataFrame(
         [[1.0, 2.0], [3.0, 4.0]],
-        index=pd.date_range("2023-01-01", periods=2, freq="D"),
+        index=["TEST_A+D1", "TEST_A+D2"],
         columns=["MENU_1", "MENU_2"],
     )
-    pred_df["date"] = pred_df.index
-    pred_df["row_key"] = ["TEST_A+D1", "TEST_A+D2"]
-    preds = pred_df.set_index("row_key")
 
-    out = format_submission(sample_df, preds, date_col="date")
+    out = format_submission(sample_df, preds)
 
     # First row parsed successfully
-    assert out.loc[0, "date"] == pd.Timestamp("2023-01-01")
-    assert out.loc[0, "MENU_1"] == 1.0
-    assert out.loc[0, "MENU_2"] == 2.0
+    assert out.loc[0, "MENU 1"] == 1.0
+    assert out.loc[0, "MENU 2"] == 2.0
 
     # Second row had invalid key and should be filled with defaults
-    assert pd.isna(out.loc[1, "date"])
-    assert out.loc[1, "MENU_1"] == 0.0
-    assert out.loc[1, "MENU_2"] == 0.0
+    assert out.loc[1, "MENU 1"] == 0.0
+    assert out.loc[1, "MENU 2"] == 0.0
+
+    # Column order and names preserved
+    assert list(out.columns) == ["row_key", "MENU 1", "MENU 2"]


### PR DESCRIPTION
## Summary
- add `normalize_series_name` helper to standardize menu identifiers
- rework `format_submission` to map normalized menus and fill predictions via row keys
- simplify prediction workflow to use new submission formatter

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c67b6a42248328892877f28d7f118e