### PR TITLE
Improve submission formatting tests and row key parsing

### DIFF
--- a/src/timesnet_forecast/utils/io.py
+++ b/src/timesnet_forecast/utils/io.py
@@ -193,8 +193,8 @@ def parse_row_key(row_key: str) -> Tuple[str, int]:
         If the row key does not match the supported pattern.
     """
 
-    pattern = r"^(.*)\+(?:Day\s*)?(\d+)\D*$"
-    m = re.match(pattern, row_key.strip())
+    pattern = r"^(.*)\+(?:D(?:ay)?\s*)?(\d+)\D*$"
+    m = re.match(pattern, row_key.strip(), flags=re.IGNORECASE)
     if not m:
         raise ValueError(f"Unsupported row key format: {row_key}")
 

--- a/tests/test_format_submission.py
+++ b/tests/test_format_submission.py
@@ -8,12 +8,34 @@ sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
 from timesnet_forecast.utils.io import format_submission
 
 
-def test_format_submission_invalid_row_key():
+def test_format_submission_row_key_variants():
     sample_df = pd.DataFrame(
         {
-            "row_key": ["TEST_A+Day 1", "BAD_KEY"],
-            "MENU 1": [0.0, 0.0],
-            "MENU 2": [0.0, 0.0],
+            "row_key": ["TEST_A+Day 1", "TEST_A+D2", "TEST_A+3일"],
+            "MENU 1": [0.0, 0.0, 0.0],
+            "MENU 2": [0.0, 0.0, 0.0],
+        }
+    )
+
+    preds = pd.DataFrame(
+        [[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]],
+        index=["TEST_A+D1", "TEST_A+D2", "TEST_A+D3"],
+        columns=["MENU_1", "MENU_2"],
+    )
+
+    out = format_submission(sample_df, preds)
+
+    assert list(out["MENU 1"]) == [1.0, 3.0, 5.0]
+    assert list(out["MENU 2"]) == [2.0, 4.0, 6.0]
+    assert list(out.columns) == ["row_key", "MENU 1", "MENU 2"]
+
+
+def test_format_submission_invalid_row_key_and_missing_pred():
+    sample_df = pd.DataFrame(
+        {
+            "row_key": ["TEST_A+Day 1", "BAD_KEY", "TEST_A+Day 3"],
+            "MENU 1": [0.0, 0.0, 0.0],
+            "MENU 2": [0.0, 0.0, 0.0],
         }
     )
 
@@ -25,7 +47,7 @@ def test_format_submission_invalid_row_key():
 
     out = format_submission(sample_df, preds)
 
-    # First row parsed successfully
+    # First row parsed successfully and prediction found
     assert out.loc[0, "MENU 1"] == 1.0
     assert out.loc[0, "MENU 2"] == 2.0
 
@@ -33,5 +55,10 @@ def test_format_submission_invalid_row_key():
     assert out.loc[1, "MENU 1"] == 0.0
     assert out.loc[1, "MENU 2"] == 0.0
 
+    # Third row had no prediction and should be filled with defaults
+    assert out.loc[2, "MENU 1"] == 0.0
+    assert out.loc[2, "MENU 2"] == 0.0
+
     # Column order and names preserved
     assert list(out.columns) == ["row_key", "MENU 1", "MENU 2"]
+

--- a/tests/test_parse_row_key.py
+++ b/tests/test_parse_row_key.py
@@ -13,3 +13,7 @@ def test_parse_row_key_day():
 
 def test_parse_row_key_korean():
     assert parse_row_key("TEST_00+1일") == ("TEST_00", 1)
+
+
+def test_parse_row_key_d_prefix():
+    assert parse_row_key("TEST_00+D1") == ("TEST_00", 1)


### PR DESCRIPTION
## Summary
- expand `parse_row_key` to accept `+D1` style row keys and ignore case
- add tests covering various row key formats, invalid keys, and missing predictions
- verify format_submission operates with DataFrame-based predictions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c67e15b73483289d11e38d95bc6220