### PR TITLE
Normalize series names for forecasts and submissions

### DIFF
--- a/src/timesnet_forecast/predict.py
+++ b/src/timesnet_forecast/predict.py
@@ -152,7 +152,7 @@ def predict_once(cfg: Dict) -> str:
         pred_list.append(pred_df)
 
     # Format submission
-    preds = pd.concat(pred_list, ignore_index=False)
+    preds = io_utils.merge_forecasts(pred_list)
     sub = io_utils.format_submission(sample, preds)
     os.makedirs(os.path.dirname(cfg_used["submission"]["out_path"]), exist_ok=True)
     sub.to_csv(cfg_used["submission"]["out_path"], index=False, encoding="utf-8-sig")


### PR DESCRIPTION
## Summary
- add `normalize_series_name` helper to reuse `normalize_id`
- merge forecast dataframes with normalized menu names
- use merged forecasts in prediction pipeline for submission formatting

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c67f16bad0832883413e5b881c342c