### PR TITLE
Add learning rate scheduler support

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -26,6 +26,11 @@ train:
   grad_clip_norm: 1.0
   amp: true
   compile: true
+  lr_scheduler:
+    type: null               # "StepLR" | "ReduceLROnPlateau" | null
+    step_size: 10            # for StepLR
+    gamma: 0.1               # for StepLR
+    patience: 5              # for ReduceLROnPlateau
   matmul_precision: "medium"
   num_workers: 4
   pin_memory: true


### PR DESCRIPTION
## Summary
- add optional learning rate scheduler (ReduceLROnPlateau or StepLR)
- step scheduler with validation WSMAPE each epoch
- expose scheduler settings in config and default YAML

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6b3c9e9388328bdbf0c0f3a777e34