### PR TITLE
feat: add data augmentation options

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,6 @@
 - Optional early stopping: set `train.early_stopping_patience` to an integer to stop training
   when validation WSMAPE does not improve for that many consecutive epochs. Leave it unset or
   `null` to disable early stopping.
+- Simple data augmentation can be enabled via the `data.augment` section of the config.
+  - `add_noise_std`: standard deviation of Gaussian noise added to input windows.
+  - `time_shift`: maximum number of time steps to randomly shift each window's start index.

--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -9,6 +9,9 @@ data:
   horizon: 7
   fill_missing_dates: true
   encoding: "utf-8-sig"
+  augment:
+    add_noise_std: 0.0       # 표준편차; 0이면 사용 안 함
+    time_shift: 0            # 입력 시퀀스 시작 위치 랜덤 시프트 범위
 
 preprocess:
   to_wide: true

--- a/src/timesnet_forecast/train.py
+++ b/src/timesnet_forecast/train.py
@@ -69,9 +69,10 @@ def _build_dataloader(
     shuffle: bool,
     drop_last: bool,
     recursive_pred_len: int | None = None,
+    augment: Dict | None = None,
 ) -> DataLoader:
     datasets = [
-        SlidingWindowDataset(a, input_len, pred_len, mode, recursive_pred_len)
+        SlidingWindowDataset(a, input_len, pred_len, mode, recursive_pred_len, augment)
         for a in arrays
     ]
     if len(datasets) == 1:
@@ -210,14 +211,16 @@ def train_once(cfg: Dict) -> Tuple[float, Dict]:
     dl_train = _build_dataloader(
         train_arrays, input_len, pred_len, mode, cfg["train"]["batch_size"],
         cfg["train"]["num_workers"], cfg["train"]["pin_memory"], cfg["train"]["persistent_workers"],
-        cfg["train"]["prefetch_factor"], shuffle=True, drop_last=True
+        cfg["train"]["prefetch_factor"], shuffle=True, drop_last=True,
+        augment=cfg["data"].get("augment"),
     )
     dl_val = _build_dataloader(
         val_arrays, input_len, pred_len, mode, batch_size=cfg["train"]["batch_size"],
         num_workers=cfg["train"]["num_workers"], pin_memory=cfg["train"]["pin_memory"],
         persistent_workers=cfg["train"]["persistent_workers"], prefetch_factor=cfg["train"]["prefetch_factor"],
         shuffle=False, drop_last=False,
-        recursive_pred_len=(pred_len if mode == "recursive" else None)
+        recursive_pred_len=(pred_len if mode == "recursive" else None),
+        augment=None,
     )
     if len(dl_val.dataset) == 0:
         raise ValueError("Validation split has no windows; increase train.val.holdout_days or adjust model.input_len/pred_len.")


### PR DESCRIPTION
## Summary
- support optional data augmentation (Gaussian noise, time shift) in SlidingWindowDataset
- expose augmentation controls via config and training pipeline
- document augmentation usage and defaults

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6b515d6cc8328873a6901dfd5573b