### PR TITLE
Rename inception kernel config to kernel_set

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,4 @@
 - Simple data augmentation can be enabled via the `data.augment` section of the config.
   - `add_noise_std`: standard deviation of Gaussian noise added to input windows.
   - `time_shift`: maximum number of time steps to randomly shift each window's start index.
+- Configuration option `model.inception_kernel_set` has been renamed to `model.kernel_set`. The previous name is still accepted for backward compatibility.

--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -54,7 +54,7 @@ model:
   n_layers: 3
   dropout: 0.1
   k_periods: 4
-  inception_kernel_set: [3, 5, 7]
+  kernel_set: [3, 5, 7]
   activation: "gelu"
 
 tuning:

--- a/src/timesnet_forecast/config.py
+++ b/src/timesnet_forecast/config.py
@@ -67,6 +67,11 @@ class Config:
         base = load_yaml(config_path)
         if overrides:
             base = apply_overrides(base, overrides)
+        # Backward compatibility: rename inception_kernel_set -> kernel_set
+        model_cfg = base.get("model", {})
+        if "inception_kernel_set" in model_cfg and "kernel_set" not in model_cfg:
+            model_cfg["kernel_set"] = model_cfg.pop("inception_kernel_set")
+            base["model"] = model_cfg
         return Config(raw=base)
 
     def get(self, path: str, default: Any = None) -> Any:

--- a/src/timesnet_forecast/predict.py
+++ b/src/timesnet_forecast/predict.py
@@ -78,7 +78,7 @@ def predict_once(cfg: Dict) -> str:
         d_model=int(cfg_used["model"]["d_model"]),
         n_layers=int(cfg_used["model"]["n_layers"]),
         k_periods=int(cfg_used["model"]["k_periods"]),
-        kernel_set=list(cfg_used["model"]["inception_kernel_set"]),
+        kernel_set=list(cfg_used["model"]["kernel_set"]),
         dropout=float(cfg_used["model"]["dropout"]),
         activation=str(cfg_used["model"]["activation"]),
         mode=str(cfg_used["model"]["mode"]),

--- a/src/timesnet_forecast/train.py
+++ b/src/timesnet_forecast/train.py
@@ -232,7 +232,7 @@ def train_once(cfg: Dict) -> Tuple[float, Dict]:
         d_model=int(cfg["model"]["d_model"]),
         n_layers=int(cfg["model"]["n_layers"]),
         k_periods=int(cfg["model"]["k_periods"]),
-        kernel_set=list(cfg["model"]["inception_kernel_set"]),
+        kernel_set=list(cfg["model"]["kernel_set"]),
         dropout=float(cfg["model"]["dropout"]),
         activation=str(cfg["model"]["activation"]),
         mode=mode,


### PR DESCRIPTION
## Summary
- rename `model.inception_kernel_set` to `model.kernel_set`
- update training & prediction code to use new key
- add backward-compatibility for old config files

## Testing
- `pytest tests/test_parse_row_key.py -q`
- `pytest tests/test_format_submission.py -q`
- `pytest tests/test_periodicity_transform.py -q` *(tests passed, manual interrupt required)*
- `pytest tests/test_dummy_training.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6b8d857fc83288d5da06af8be42aa