### PR TITLE
Switch training to SMAPE metric and disable store weighting

### DIFF
--- a/src/timesnet_forecast/utils/metrics.py
+++ b/src/timesnet_forecast/utils/metrics.py
@@ -49,3 +49,19 @@ def wsmape_grouped(
         item_scores = [smape_item(y_true[:, j], y_pred[:, j]) for j in idxs]
         score += wnorm.get(st, 0.0) * (float(np.mean(item_scores)) if item_scores else 0.0)
     return float(score)
+
+
+def smape_mean(y_true: np.ndarray, y_pred: np.ndarray, eps: float = 1e-8) -> float:
+    """Mean symmetric MAPE across all series.
+
+    Uses the same masking strategy as :func:`_smape_np` in the unit tests:
+    only points where the actual value magnitude exceeds ``eps`` contribute
+    to the final mean.
+    """
+    assert y_true.shape == y_pred.shape, "y_true and y_pred must have same shape"
+    mask = np.abs(y_true) > eps
+    if not np.any(mask):
+        return 0.0
+    denom = np.abs(y_true) + np.abs(y_pred)
+    smape = 2.0 * np.abs(y_pred - y_true)[mask] / denom[mask]
+    return float(np.mean(smape))

--- a/tests/test_dummy_training.py
+++ b/tests/test_dummy_training.py
@@ -9,14 +9,7 @@ import torch
 sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
 
 from timesnet_forecast.models.timesnet import TimesNet
-from timesnet_forecast.utils.metrics import wsmape_grouped
-
-
-def _smape_np(y_true: np.ndarray, y_pred: np.ndarray, eps: float = 1e-8) -> float:
-    """Compute symmetric MAPE over the last axis."""
-    mask = np.abs(y_true) > eps
-    denom = np.abs(y_true) + np.abs(y_pred)
-    return float(np.mean(2.0 * np.abs(y_pred - y_true)[mask] / denom[mask]))
+from timesnet_forecast.utils.metrics import wsmape_grouped, smape_mean
 
 
 def test_dummy_training_smape_wsmape():
@@ -73,7 +66,7 @@ def test_dummy_training_smape_wsmape():
     y_true = actual.numpy()
     y_pred = pred.numpy()
 
-    smape = _smape_np(y_true, y_pred)
+    smape = smape_mean(y_true, y_pred)
     wsmape = wsmape_grouped(y_true, y_pred, ids=["A_1", "A_2"])
 
     assert smape < 0.1


### PR DESCRIPTION
## Summary
- Add `smape_mean` helper for ungrouped SMAPE computation
- Remove store-weighted evaluation and validate using SMAPE
- Update unit test to rely on new SMAPE function

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c761604cac8328b54107d4ea3bc3ea