### PR TITLE
Refactor TimesNet output to retain per-series predictions

### DIFF
--- a/src/timesnet_forecast/predict.py
+++ b/src/timesnet_forecast/predict.py
@@ -83,9 +83,9 @@ def predict_once(cfg: Dict) -> str:
         activation=str(cfg_used["model"]["activation"]),
         mode=str(cfg_used["model"]["mode"]),
     ).to(device)
-    # Lazily constructed layers depend on number of series (channels).
-    dummy = torch.zeros(1, len(ids), 1, device=device)
-    model._build_lazy(N=len(ids), L=1, x=dummy)
+    # Lazily construct layers (independent of number of series now).
+    dummy = torch.zeros(1, 1, 1, device=device)
+    model._build_lazy(L=1, x=dummy)
     state = torch.load(model_file, map_location="cpu")
     # Checkpoints saved with torch.compile or DataParallel may prefix parameter names.
     clean_state = {


### PR DESCRIPTION
## Summary
- Preserve series dimension through pooling and replace shared head with per-series linear layer
- Simplify lazy initialization and update forward to return `[B, pred_len, N]` directly
- Adjust prediction pipeline for new lazy build interface

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c769ed45e48328a55b92d29b74872c