### PR TITLE
Add series-chunked processing to TimesNet

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -57,6 +57,7 @@ model:
   k_periods: 4
   kernel_set: [3, 5, 7]
   activation: "gelu"
+  series_chunk: 128
 
 tuning:
   enabled: true

--- a/configs/search_space.yaml
+++ b/configs/search_space.yaml
@@ -2,5 +2,6 @@ model.d_model: {low: 64, high: 128, step: 64, type: "int"}
 model.n_layers: {low: 2, high: 5, step: 1, type: "int"}
 model.dropout: {low: 0.0, high: 0.5, type: "float"}
 model.k_periods: {low: 2, high: 8, step: 1, type: "int"}
+model.series_chunk: {choices: [64, 128, 256], type: "categorical"}
 train.lr: {low: 1.0e-4, high: 5.0e-3, log: true, type: "float"}
 train.batch_size: {choices: [128, 256, 384], type: "categorical"}

--- a/src/timesnet_forecast/predict.py
+++ b/src/timesnet_forecast/predict.py
@@ -82,6 +82,7 @@ def predict_once(cfg: Dict) -> str:
         dropout=float(cfg_used["model"]["dropout"]),
         activation=str(cfg_used["model"]["activation"]),
         mode=str(cfg_used["model"]["mode"]),
+        series_chunk=int(cfg_used["model"].get("series_chunk", 128)),
     ).to(device)
     # Lazily construct layers (independent of number of series now).
     dummy = torch.zeros(1, 1, 1, device=device)

--- a/src/timesnet_forecast/train.py
+++ b/src/timesnet_forecast/train.py
@@ -261,6 +261,7 @@ def train_once(cfg: Dict) -> Tuple[float, Dict]:
         dropout=float(cfg["model"]["dropout"]),
         activation=str(cfg["model"]["activation"]),
         mode=mode,
+        series_chunk=int(cfg["model"].get("series_chunk", 128)),
     ).to(device)
 
     # Lazily build model parameters so that downstream utilities see them


### PR DESCRIPTION
## Summary
- add optional `series_chunk` argument to `TimesNet` to process series dimension in chunks
- expose `series_chunk` in config and CLI for tuning
- update training and prediction flows to use chunking

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c785f19c3483288d4b3577e2377258