### PR TITLE
Remove unused incept attribute

### DIFF
--- a/src/timesnet_forecast/models/timesnet.py
+++ b/src/timesnet_forecast/models/timesnet.py
@@ -153,7 +153,6 @@ class TimesNet(nn.Module):
         self.pred_len = int(pred_len)
         self.period = PeriodicityTransform(k_periods=k_periods)
         self.k = int(k_periods)
-        self.incept: List[InceptionBlock] = []
         self.act = activation
         # Conv will process each series independently along the temporal dimension.
         # We don't know the period-length ``P`` at build time, so layers are built lazily


### PR DESCRIPTION
## Summary
- drop redundant `self.incept` attribute from TimesNet implementation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c786f31fec832885aacc652f5de8de