### PR TITLE
refactor: simplify lazy builder interface

### DIFF
--- a/src/timesnet_forecast/models/timesnet.py
+++ b/src/timesnet_forecast/models/timesnet.py
@@ -168,11 +168,10 @@ class TimesNet(nn.Module):
         self.n_layers = int(n_layers)
         self.series_chunk = int(series_chunk)
 
-    def _build_lazy(self, L: int, x: torch.Tensor) -> None:
-        """Instantiate convolutional blocks once input length is known.
+    def _build_lazy(self, x: torch.Tensor) -> None:
+        """Instantiate convolutional blocks on first use.
 
         Args:
-            L: flattened temporal length (``K*P``)
             x: reference tensor for device/dtype placement
         """
         # Stem that maps each series (treated as a separate "batch" item) from 1 → d_model channels.
@@ -214,7 +213,7 @@ class TimesNet(nn.Module):
             n = e - s
             z = z.permute(0, 3, 1, 2).contiguous().view(B * n, 1, K * P)
             if not self._lazy_built:
-                self._build_lazy(L=K * P, x=z)
+                self._build_lazy(x=z)
             z = self.stem(z)  # [B*n, d_model, K*P]
             z = self.blocks(z)  # [B*n, d_model, K*P]
             z = self.pool(z).squeeze(-1)  # [B*n, d_model]

--- a/src/timesnet_forecast/predict.py
+++ b/src/timesnet_forecast/predict.py
@@ -86,7 +86,7 @@ def predict_once(cfg: Dict) -> str:
     ).to(device)
     # Lazily construct layers (independent of number of series now).
     dummy = torch.zeros(1, 1, 1, device=device)
-    model._build_lazy(L=1, x=dummy)
+    model._build_lazy(x=dummy)
     state = torch.load(model_file, map_location="cpu")
     # Checkpoints saved with torch.compile or DataParallel may prefix parameter names.
     clean_state = {


### PR DESCRIPTION
## Summary
- drop unused `L` argument from `TimesNet._build_lazy`
- update call sites to use simplified interface

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c788f1fc908328bcce4395381b955d