### PR TITLE
refactor search space

### DIFF
--- a/configs/search_space.yaml
+++ b/configs/search_space.yaml
@@ -2,6 +2,5 @@ model.d_model: {low: 128, high: 512, step: 64, type: "int"}
 model.n_layers: {low: 2, high: 6, step: 1, type: "int"}
 model.dropout: {low: 0.0, high: 0.5, type: "float"}
 model.k_periods: {low: 2, high: 8, step: 1, type: "int"}
-model.series_chunk: {choices: [64, 128, 256], type: "categorical"}
-train.lr: {low: 1.0e-4, high: 5.0e-3, log: true, type: "float"}
+train.lr: {low: 1.0e-4, high: 1.0e-3, log: true, type: "float"}
 train.batch_size: {choices: [64, 128 ], type: "categorical"}


### PR DESCRIPTION
## Summary
- narrow train learning rate search space to max 1e-3
- drop obsolete model.series_chunk parameter

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c79827b3ec8328b00a6aa90f4ebc13