### PR TITLE
Remove series_chunk config option

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -56,7 +56,6 @@ model:
   k_periods: 4
   kernel_set: [3, 5, 7]
   activation: "gelu"
-  series_chunk: 128
 
 tuning:
   enabled: true

--- a/src/timesnet_forecast/predict.py
+++ b/src/timesnet_forecast/predict.py
@@ -82,7 +82,6 @@ def predict_once(cfg: Dict) -> str:
         dropout=float(cfg_used["model"]["dropout"]),
         activation=str(cfg_used["model"]["activation"]),
         mode=str(cfg_used["model"]["mode"]),
-        series_chunk=int(cfg_used["model"].get("series_chunk", 128)),
     ).to(device)
     # Lazily construct layers (independent of number of series now).
     dummy = torch.zeros(1, 1, 1, device=device)

--- a/src/timesnet_forecast/train.py
+++ b/src/timesnet_forecast/train.py
@@ -270,7 +270,6 @@ def train_once(cfg: Dict) -> Tuple[float, Dict]:
         dropout=float(cfg["model"]["dropout"]),
         activation=str(cfg["model"]["activation"]),
         mode=mode,
-        series_chunk=int(cfg["model"].get("series_chunk", 128)),
     ).to(device)
 
     # Lazily build model parameters so that downstream utilities see them


### PR DESCRIPTION
## Summary
- drop `model.series_chunk` from the default configuration
- stop passing `series_chunk` from training and prediction code

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c799cdd2e48328a656fe84a3a79170