### PR TITLE
Add gradient accumulation to default config

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -25,6 +25,7 @@ train:
   epochs: 70
   early_stopping_patience: 10
   batch_size: 64
+  accumulation_steps: 1
   lr: 1.0e-3
   weight_decay: 1.0e-6
   grad_clip_norm: 1.0


### PR DESCRIPTION
## Summary
- expose `accumulation_steps` setting in training config with default of 1

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7c87f86508328ab445acd29e2b998