### PR TITLE
Reduce batch size search range

### DIFF
--- a/configs/search_space.yaml
+++ b/configs/search_space.yaml
@@ -3,4 +3,4 @@ model.n_layers: {low: 2, high: 6, step: 1, type: "int"}
 model.dropout: {low: 0.0, high: 0.5, type: "float"}
 model.k_periods: {low: 2, high: 8, step: 1, type: "int"}
 train.lr: {low: 1.0e-4, high: 1.0e-3, log: true, type: "float"}
-train.batch_size: {choices: [64, 128 ], type: "categorical"}
+train.batch_size: {choices: [32, 64], type: "categorical"}


### PR DESCRIPTION
## Summary
- Limit train batch size search options to 32 and 64

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7c91bf7bc8328836cb81ae5de0cfe