### PR TITLE
feat: add channels-last option to inception block

### DIFF
--- a/src/timesnet_forecast/models/timesnet.py
+++ b/src/timesnet_forecast/models/timesnet.py
@@ -96,16 +96,36 @@ class PeriodicityTransform(nn.Module):
 
 
 class InceptionBlock(nn.Module):
-    def __init__(self, in_ch: int, out_ch: int, kernel_set: List[int], dropout: float, act: str) -> None:
+    def __init__(
+        self,
+        in_ch: int,
+        out_ch: int,
+        kernel_set: List[int],
+        dropout: float,
+        act: str,
+        channels_last: bool = False,
+    ) -> None:
         super().__init__()
+        self.channels_last = bool(channels_last)
         self.paths = nn.ModuleList()
         for k in kernel_set:
-            pad = k // 2
-            self.paths.append(nn.Conv1d(in_ch, out_ch, kernel_size=k, padding=pad))
-        self.proj = nn.Conv1d(out_ch * len(kernel_set), out_ch, kernel_size=1)
+            pad = (k - 1) // 2 if self.channels_last else k // 2
+            if self.channels_last:
+                self.paths.append(
+                    nn.Conv2d(in_ch, out_ch, kernel_size=(k, 1), padding=(pad, 0))
+                )
+            else:
+                self.paths.append(nn.Conv1d(in_ch, out_ch, kernel_size=k, padding=pad))
+        if self.channels_last:
+            self.proj = nn.Conv2d(out_ch * len(kernel_set), out_ch, kernel_size=1)
+        else:
+            self.proj = nn.Conv1d(out_ch * len(kernel_set), out_ch, kernel_size=1)
         # Residual projection if channel dims differ
         if in_ch != out_ch:
-            self.res_proj = nn.Conv1d(in_ch, out_ch, kernel_size=1)
+            if self.channels_last:
+                self.res_proj = nn.Conv2d(in_ch, out_ch, kernel_size=1)
+            else:
+                self.res_proj = nn.Conv1d(in_ch, out_ch, kernel_size=1)
         else:
             self.res_proj = nn.Identity()
         self.dropout = nn.Dropout(dropout)
@@ -117,12 +137,15 @@ class InceptionBlock(nn.Module):
             self.act = nn.GELU()
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        """
-        x: [B, C, L]
+        """Apply inception-style convolutions.
+
+        Args:
+            x: [B, C, L] when ``channels_last`` is ``False``
+               or [B, C, L, 1] when ``channels_last`` is ``True``
         """
         res = self.res_proj(x)
-        feats = [p(x) for p in self.paths]  # list of [B, out_ch, L]
-        z = torch.cat(feats, dim=1)         # [B, out_ch*P, L]
+        feats = [p(x) for p in self.paths]
+        z = torch.cat(feats, dim=1)
         z = self.proj(z)
         z = self.act(z)
         z = self.dropout(z)


### PR DESCRIPTION
## Summary
- add `channels_last` flag to `InceptionBlock` for optional 2D convolution paths
- support `[B, C, L, 1]` tensors with updated residual and projection layers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7fc8d7d7c8328b4e5bf64a98cc8a6