### PR TITLE
Add checkpoint flag and CUDA graphs config

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -31,6 +31,7 @@ train:
   grad_clip_norm: 1.0
   amp: true
   compile: true
+  cuda_graphs: false
   lr_scheduler:
     type: "cosine"
     T_max: ${train.epochs}   # or explicit integer

--- a/src/timesnet_forecast/predict.py
+++ b/src/timesnet_forecast/predict.py
@@ -84,6 +84,7 @@ def predict_once(cfg: Dict) -> str:
         activation=str(cfg_used["model"]["activation"]),
         mode=str(cfg_used["model"]["mode"]),
         channels_last=cfg_used["train"]["channels_last"],
+        use_checkpoint=not cfg_used["train"].get("cuda_graphs", False),
     ).to(device)
     # Lazily construct layers (independent of number of series now).
     dummy = torch.zeros(1, 1, 1, device=device)

--- a/src/timesnet_forecast/train.py
+++ b/src/timesnet_forecast/train.py
@@ -332,6 +332,7 @@ def train_once(cfg: Dict) -> Tuple[float, Dict]:
         activation=str(cfg["model"]["activation"]),
         mode=mode,
         channels_last=cfg["train"]["channels_last"],
+        use_checkpoint=not cfg["train"].get("cuda_graphs", False),
     ).to(device)
 
     # Lazily build model parameters so that downstream utilities see them


### PR DESCRIPTION
## Summary
- add `use_checkpoint` option to TimesNet allowing checkpointing to be toggled
- wire config `train.cuda_graphs` to disable checkpointing when using CUDA graphs
- propagate flag to model instantiation in training and prediction

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c80d075bf48328aea476c92c2160cb