### PR TITLE
Freeze dropout during CUDA graph capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,4 @@
   - `add_noise_std`: standard deviation of Gaussian noise added to input windows.
   - `time_shift`: maximum number of time steps to randomly shift each window's start index.
 - Configuration option `model.inception_kernel_set` has been renamed to `model.kernel_set`. The previous name is still accepted for backward compatibility.
+- Using CUDA Graphs (`train.cuda_graphs: true`) disables dropout because the model is placed in evaluation mode during graph capture. This trades regularization for faster execution.


### PR DESCRIPTION
## Summary
- Freeze dropout during CUDA Graph capture by evaluating the model during graph recording and restoring training mode afterwards.
- Note in the README that enabling CUDA Graphs disables dropout regularization.

## Testing
- `pytest -q --disable-warnings`


------
https://chatgpt.com/codex/tasks/task_e_68c80e593b3c8328bf06e572bf3ab473