### PR TITLE
Add pmax cap configuration knob and enforce during training

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -56,6 +56,7 @@ model:
   n_layers: 3
   dropout: 0.1
   k_periods: 4
+  pmax_cap: 730            # 2-year cap
   kernel_set: [3, 5, 7]
   activation: "gelu"
 

--- a/src/timesnet_forecast/train.py
+++ b/src/timesnet_forecast/train.py
@@ -294,7 +294,10 @@ def train_once(cfg: Dict) -> Tuple[float, Dict]:
 
     # --- compute global period length
     k_periods = int(cfg["model"].get("k_periods", 0))
-    pmax_global = _compute_pmax_global(train_arrays, k_periods)
+    pmax_global = min(
+        _compute_pmax_global(train_arrays, k_periods),
+        cfg["model"].get("pmax_cap", 730),
+    )
     cfg.setdefault("model", {})
     cfg["model"]["pmax"] = int(pmax_global)
 


### PR DESCRIPTION
## Summary
- add `pmax_cap` option under `model` with default 730 day limit
- cap global `pmax` during training so padding and model config respect limit

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c824c9b0a48328aa78f2bdfad6061b