### PR TITLE
Document pmax cap and add forward shape tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,5 @@
   - `time_shift`: maximum number of time steps to randomly shift each window's start index.
 - Configuration option `model.inception_kernel_set` has been renamed to `model.kernel_set`. The previous name is still accepted for backward compatibility.
 - Using CUDA Graphs (`train.cuda_graphs: true`) disables dropout because the model is placed in evaluation mode during graph capture. This trades regularization for faster execution.
+- `model.pmax_cap` limits the automatically inferred maximum period length. During training the dominant period across all series is detected and then clipped to this cap to avoid extremely long seasonal windows.
+- The model "telescopes" input sequences: `TimesNet.forward` always crops to the last `input_len` steps, so passing extra history at inference produces the same `[B, pred_len, N]` shaped output as training.

--- a/src/timesnet_forecast/models/timesnet.py
+++ b/src/timesnet_forecast/models/timesnet.py
@@ -231,10 +231,11 @@ class TimesNet(nn.Module):
           recursive: [B, 1, N]
         """
         B, T, N = x.shape
-        z_all = self.period(x)
+        x_tail = x[:, -self.input_len:, :]
+        z_all = self.period(x_tail)
         if z_all.size(1) == 0:
             out_steps = self.pred_len if self.mode == "direct" else 1
-            return x.new_zeros(B, out_steps, N)
+            return x_tail.new_zeros(B, out_steps, N)
 
         z = z_all[:, :, -self.input_len:, :]  # [B, K, input_len, N]
         K = z.size(1)

--- a/tests/test_global_pmax.py
+++ b/tests/test_global_pmax.py
@@ -3,11 +3,14 @@ from pathlib import Path
 import sys
 
 import numpy as np
+import pandas as pd
 
 # Ensure the project src is on the path for imports
 sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
 
 from timesnet_forecast.train import _compute_pmax_global
+from timesnet_forecast.config import Config
+from timesnet_forecast import train
 
 
 def test_compute_pmax_global():
@@ -18,4 +21,62 @@ def test_compute_pmax_global():
     arr = np.stack([s1, s2], axis=1)
     pmax = _compute_pmax_global([arr], k=1)
     assert pmax == 50
+
+
+def test_pmax_cap_applied(tmp_path, monkeypatch):
+    # Create a tiny training CSV
+    dates = pd.date_range("2023-01-01", periods=6, freq="D")
+    rows = []
+    for d in dates:
+        rows.append({"date": d, "id": "S1", "target": 1.0})
+        rows.append({"date": d, "id": "S2", "target": 2.0})
+    df = pd.DataFrame(rows)
+    csv_path = tmp_path / "train.csv"
+    df.to_csv(csv_path, index=False)
+
+    overrides = [
+        f"data.train_csv={csv_path}",
+        "data.date_col=date",
+        "data.id_col=id",
+        "data.target_col=target",
+        "data.encoding=utf-8",
+        "data.fill_missing_dates=False",
+        "train.device=cpu",
+        "train.epochs=1",
+        "train.batch_size=2",
+        "train.num_workers=1",
+        "train.pin_memory=False",
+        "train.persistent_workers=False",
+        "train.prefetch_factor=2",
+        "train.amp=False",
+        "train.compile=False",
+        "train.cuda_graphs=False",
+        "train.val.strategy=holdout",
+        "train.val.holdout_days=3",
+        "preprocess.normalize=none",
+        "preprocess.normalize_per_series=True",
+        "preprocess.eps=1e-8",
+        "model.mode=direct",
+        "model.input_len=2",
+        "model.pred_len=1",
+        "model.d_model=8",
+        "model.n_layers=1",
+        "model.dropout=0.0",
+        "model.k_periods=1",
+        "model.kernel_set=[3]",
+        "model.pmax_cap=5",
+        "train.lr=1e-3",
+        "train.weight_decay=0.0",
+        "train.grad_clip_norm=0.0",
+        f"artifacts.dir={tmp_path}/artifacts",
+        "artifacts.model_file=model.pth",
+        "artifacts.scaler_file=scaler.pkl",
+        "artifacts.schema_file=schema.json",
+        "artifacts.config_file=config.yaml",
+    ]
+    cfg = Config.from_files("configs/default.yaml", overrides=overrides).to_dict()
+
+    monkeypatch.setattr(train, "_compute_pmax_global", lambda arrays, k: 50)
+    train.train_once(cfg)
+    assert cfg["model"]["pmax"] == 5
 

--- a/tests/test_timesnet_forward.py
+++ b/tests/test_timesnet_forward.py
@@ -1,0 +1,41 @@
+import sys
+from pathlib import Path
+
+import torch
+
+# Ensure the project src is on the path for imports
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from timesnet_forecast.models.timesnet import TimesNet
+
+
+def test_forward_shape_and_tail_processing():
+    B, L, H, N = 2, 16, 4, 3
+    torch.manual_seed(0)
+
+    model = TimesNet(
+        input_len=L,
+        pred_len=H,
+        d_model=8,
+        n_layers=1,
+        k_periods=1,
+        pmax=L,
+        kernel_set=[3],
+        dropout=0.0,
+        activation="gelu",
+        mode="direct",
+    )
+    with torch.no_grad():
+        model(torch.zeros(1, L, N))  # build lazy layers
+
+    x = torch.randn(B, L, N)
+    model.train()
+    out_train = model(x)
+    model.eval()
+    out_eval = model(x)
+    assert out_train.shape == out_eval.shape == (B, H, N)
+
+    long_x = torch.randn(B, L + 5, N)
+    out_long = model(long_x)
+    out_tail = model(long_x[:, -L:, :])
+    assert torch.allclose(out_long, out_tail, atol=1e-6)


### PR DESCRIPTION
## Summary
- document `model.pmax_cap` and the telescoping behaviour in the README
- ensure `TimesNet.forward` only uses the final `input_len` steps
- test `pmax_cap` enforcement and forward tail cropping

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c827c0ef888328ba8ee48fc2e604cb