### PR TITLE
Prevent manual CUDA graphs when torch.compile is enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,5 +10,6 @@
   - `time_shift`: maximum number of time steps to randomly shift each window's start index.
 - Configuration option `model.inception_kernel_set` has been renamed to `model.kernel_set`. The previous name is still accepted for backward compatibility.
 - Using CUDA Graphs (`train.cuda_graphs: true`) disables dropout because the model is placed in evaluation mode during graph capture. This trades regularization for faster execution.
+- Manual CUDA graph capture (`train.cuda_graphs`) and `torch.compile` (`train.compile`) are mutually exclusive. TorchDynamo already performs graph capture and its compiled modules cannot be re-captured safely.
 - `model.pmax_cap` limits the automatically inferred maximum period length. During training the dominant period across all series is detected and then clipped to this cap to avoid extremely long seasonal windows.
 - The model "telescopes" input sequences: `TimesNet.forward` always crops to the last `input_len` steps, so passing extra history at inference produces the same `[B, pred_len, N]` shaped output as training.

--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -31,7 +31,7 @@ train:
   grad_clip_norm: 1.0
   amp: true
   compile: true
-  cuda_graphs: true
+  cuda_graphs: false         # Mutually exclusive with compile
   lr_scheduler:
     type: "cosine"
     T_max: ${train.epochs}   # or explicit integer

--- a/tests/test_cuda_graphs_compile.py
+++ b/tests/test_cuda_graphs_compile.py
@@ -1,0 +1,39 @@
+import sys
+from pathlib import Path
+
+import torch
+
+# Ensure the project src is on the path for imports
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from timesnet_forecast import train
+
+
+def _cuda_device():
+    if torch.cuda.is_available():
+        return torch.device("cuda")
+
+    class _CudaDevice:
+        type = "cuda"
+
+    return _CudaDevice()
+
+
+def test_cuda_graphs_disabled_when_compile_enabled():
+    train_cfg = {
+        "cuda_graphs": True,
+        "compile": True,
+    }
+    device = _cuda_device()
+
+    assert not train._should_use_cuda_graphs(train_cfg, device)
+
+
+def test_cuda_graphs_enabled_without_compile():
+    train_cfg = {
+        "cuda_graphs": True,
+        "compile": False,
+    }
+    device = _cuda_device()
+
+    assert train._should_use_cuda_graphs(train_cfg, device)


### PR DESCRIPTION
## Summary
- gate CUDA graph capture on `train.compile` so manual capture is skipped for compiled models
- document that `train.cuda_graphs` and `train.compile` are mutually exclusive and set the default config accordingly
- add a unit test covering the CUDA graphs/compile interaction

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c834f0437483288a98b586beec8473