### PR TITLE
Pass pmax through dataloader and dataset

### DIFF
--- a/src/timesnet_forecast/data/dataset.py
+++ b/src/timesnet_forecast/data/dataset.py
@@ -20,12 +20,17 @@ class SlidingWindowDataset(Dataset):
         mode: str,  # "direct"|"recursive"
         recursive_pred_len: int | None = None,
         augment: Dict | None = None,
+        pmax_global: int | None = None,
     ) -> None:
         super().__init__()
         assert mode in ("direct", "recursive")
         self.X = wide_values.astype(np.float32)
         self.T, self.N = self.X.shape
         self.L = int(input_len)
+        pmax_global = int(pmax_global) if pmax_global is not None else None
+        if pmax_global is not None and pmax_global <= 0:
+            raise ValueError("pmax_global must be positive when provided")
+        self.window_len = int(max(self.L, pmax_global) if pmax_global is not None else self.L)
         if mode == "direct":
             self.H = int(pred_len)
         else:
@@ -55,4 +60,12 @@ class SlidingWindowDataset(Dataset):
         y = self.X[e : e + self.H, :]  # [H, N] or [1, N]
         if self.add_noise_std > 0:
             x = x + np.random.normal(scale=self.add_noise_std, size=x.shape)
+        if self.window_len > x.shape[0]:
+            pad_len = self.window_len - x.shape[0]
+            pad = np.zeros((pad_len, self.N), dtype=np.float32)
+            x = np.concatenate([pad, x.astype(np.float32, copy=False)], axis=0)
+        elif self.window_len < x.shape[0]:
+            x = x[-self.window_len :, :]
+        x = x.astype(np.float32, copy=False)
+        y = y.astype(np.float32, copy=False)
         return torch.from_numpy(x), torch.from_numpy(y)


### PR DESCRIPTION
## Summary
- pass the global pmax length from `_build_dataloader` into `SlidingWindowDataset`
- update the dataset to emit fixed-length windows so the dataloader no longer pads batches
- adjust train/validation dataloader construction to use the new parameter

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c8a63d9e24832888938df0f2ab04c5