### PR TITLE
Use full sequence for period transform

### DIFF
--- a/src/timesnet_forecast/models/timesnet.py
+++ b/src/timesnet_forecast/models/timesnet.py
@@ -233,15 +233,16 @@ class TimesNet(nn.Module):
           recursive: [B, 1, N]
         """
         B, T, N = x.shape
-        x_tail = x[:, -self.input_len:, :]
-        z_all = self.period(x_tail)
+        z_all = self.period(x)
         if z_all.size(1) == 0:
             out_steps = self.pred_len if self.mode == "direct" else 1
+            x_tail = x[:, -self.input_len:, :]
             return x_tail.new_zeros(B, out_steps, N)
 
         z = z_all[:, :, -self.input_len:, :]  # [B, K, input_len, N]
         K = z.size(1)
-        z = z.permute(0, 3, 1, 2).reshape(B * N, K, self.input_len)
+        steps = z.size(2)
+        z = z.permute(0, 3, 1, 2).reshape(B * N, K, steps)
         if not self._lazy_built:
             self.k = K
             self._build_lazy(x=z)

--- a/tests/test_timesnet_forward.py
+++ b/tests/test_timesnet_forward.py
@@ -38,4 +38,6 @@ def test_forward_shape_and_tail_processing():
     long_x = torch.randn(B, L + 5, N)
     out_long = model(long_x)
     out_tail = model(long_x[:, -L:, :])
-    assert torch.allclose(out_long, out_tail, atol=1e-6)
+    assert out_long.shape == out_tail.shape == (B, H, N)
+    # Using the full pmax input introduces extra context, so outputs can differ from tail-only processing.
+    assert not torch.allclose(out_long, out_tail, atol=1e-6)


### PR DESCRIPTION
## Summary
- compute the TimesNet period transform on the entire input sequence before slicing to the convolution window
- keep the zero-output fallback while reshaping the convolution input based on the sliced period length
- update the forward unit test to expect different outputs when additional context is provided

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c8a9abcaa88328a5357c128852bcc3