### PR TITLE
Fix TimesNet forward slicing to use leading canvas steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,4 @@
 - Using CUDA Graphs (`train.cuda_graphs: true`) disables dropout because the model is placed in evaluation mode during graph capture. This trades regularization for faster execution.
 - Manual CUDA graph capture (`train.cuda_graphs`) and `torch.compile` (`train.compile`) are mutually exclusive. TorchDynamo already performs graph capture and its compiled modules cannot be re-captured safely.
 - `model.pmax_cap` limits the automatically inferred maximum period length. During training the dominant period across all series is detected and then clipped to this cap to avoid extremely long seasonal windows.
-- The model "telescopes" input sequences: `TimesNet.forward` always crops to the last `input_len` steps, so passing extra history at inference produces the same `[B, pred_len, N]` shaped output as training.
+- The model "telescopes" input sequences: `TimesNet.forward` always crops to the first `input_len` steps of the periodic canvas, so passing extra history at inference produces the same `[B, pred_len, N]` shaped output as training.

--- a/src/timesnet_forecast/models/timesnet.py
+++ b/src/timesnet_forecast/models/timesnet.py
@@ -236,10 +236,10 @@ class TimesNet(nn.Module):
         z_all = self.period(x)
         if z_all.size(1) == 0:
             out_steps = self.pred_len if self.mode == "direct" else 1
-            x_tail = x[:, -self.input_len:, :]
-            return x_tail.new_zeros(B, out_steps, N)
+            x_head = x[:, :self.input_len, :]
+            return x_head.new_zeros(B, out_steps, N)
 
-        z = z_all[:, :, -self.input_len:, :]  # [B, K, input_len, N]
+        z = z_all[:, :, :self.input_len, :]  # leading slice [B, K, input_len, N]
         K = z.size(1)
         steps = z.size(2)
         z = z.permute(0, 3, 1, 2).reshape(B * N, K, steps)

--- a/tests/test_timesnet_forward.py
+++ b/tests/test_timesnet_forward.py
@@ -9,7 +9,7 @@ sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
 from timesnet_forecast.models.timesnet import TimesNet
 
 
-def test_forward_shape_and_tail_processing():
+def test_forward_shape_and_head_processing():
     B, L, H, N = 2, 16, 4, 3
     torch.manual_seed(0)
 
@@ -37,5 +37,5 @@ def test_forward_shape_and_tail_processing():
 
     long_x = torch.randn(B, L + 5, N)
     out_long = model(long_x)
-    out_tail = model(long_x[:, -L:, :])
-    assert out_long.shape == out_tail.shape == (B, H, N)
+    out_head = model(long_x[:, :L, :])
+    assert out_long.shape == out_head.shape == (B, H, N)


### PR DESCRIPTION
## Summary
- ensure TimesNet.forward takes the leading portion of the periodic canvas and aligns the zero-period fallback with that convention
- refresh the README description of the model's telescoping behaviour to mention leading slices
- update the forward pass unit test to exercise the head-slicing behaviour

## Testing
- pytest tests/test_timesnet_forward.py

------
https://chatgpt.com/codex/tasks/task_e_68c8bc802a5c8328afca549c5ad9b22f