### PR TITLE
Add minimum period threshold for TimesNet periodicity

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -57,6 +57,7 @@ model:
   dropout: 0.1
   k_periods: 4
   pmax_cap: 730            # 2-year cap
+  min_period_threshold: 7  # 최소 주기 하한선
   kernel_set: [3, 5, 7]
   activation: "gelu"
 

--- a/src/timesnet_forecast/predict.py
+++ b/src/timesnet_forecast/predict.py
@@ -72,6 +72,8 @@ def predict_once(cfg: Dict) -> str:
     scaler = scaler_meta["scaler"]
 
     # Build model
+    min_period_threshold = int(cfg_used["model"].get("min_period_threshold", 1))
+
     model = TimesNet(
         input_len=int(cfg_used["model"]["input_len"]),
         pred_len=int(cfg_used["model"]["pred_len"]),
@@ -79,6 +81,7 @@ def predict_once(cfg: Dict) -> str:
         n_layers=int(cfg_used["model"]["n_layers"]),
         k_periods=int(cfg_used["model"]["k_periods"]),
         pmax=int(cfg_used["model"]["pmax"]),
+        min_period_threshold=min_period_threshold,
         kernel_set=list(cfg_used["model"]["kernel_set"]),
         dropout=float(cfg_used["model"]["dropout"]),
         activation=str(cfg_used["model"]["activation"]),

--- a/src/timesnet_forecast/train.py
+++ b/src/timesnet_forecast/train.py
@@ -308,6 +308,8 @@ def train_once(cfg: Dict) -> Tuple[float, Dict]:
     pmax_global = _compute_pmax_global(train_arrays, k_periods, pmax_cap)
     cfg.setdefault("model", {})
     cfg["model"]["pmax"] = int(pmax_global)
+    min_period_threshold = int(cfg["model"].get("min_period_threshold", 1))
+    cfg["model"]["min_period_threshold"] = min_period_threshold
 
     # --- dataloaders
     input_len = int(cfg["model"]["input_len"])
@@ -338,6 +340,7 @@ def train_once(cfg: Dict) -> Tuple[float, Dict]:
         n_layers=int(cfg["model"]["n_layers"]),
         k_periods=int(cfg["model"]["k_periods"]),
         pmax=int(cfg["model"]["pmax"]),
+        min_period_threshold=min_period_threshold,
         kernel_set=list(cfg["model"]["kernel_set"]),
         dropout=float(cfg["model"]["dropout"]),
         activation=str(cfg["model"]["activation"]),


### PR DESCRIPTION
## Summary
- add a configurable minimum period threshold to PeriodicityTransform and propagate it through TimesNet
- extend the default configuration and training/prediction flows to persist and reuse the new threshold
- add a regression test to ensure the lower bound expands the populated period slots

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c8c36c80d48328ad525705972c07b3