### PR TITLE
Add loss masking support in training

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -42,6 +42,7 @@ train:
   persistent_workers: true
   prefetch_factor: 4
   channels_last: true
+  use_loss_masking: true
   val:
     strategy: "rolling"       # "holdout"|"rolling"
     holdout_days: 35          # must be >= model.input_len + model.pred_len

--- a/tests/test_clip_negative.py
+++ b/tests/test_clip_negative.py
@@ -67,10 +67,10 @@ def test_clip_negative(tmp_path, monkeypatch):
     captured = []
     orig_build = train._build_dataloader
 
-    def capture_build(arrays, *args, **kwargs):
+    def capture_build(arrays, masks, *args, **kwargs):
         for a in arrays:
             captured.append(a)
-        return orig_build(arrays, *args, **kwargs)
+        return orig_build(arrays, masks, *args, **kwargs)
 
     monkeypatch.setattr(train, "_build_dataloader", capture_build)
 

--- a/tests/test_dataset_pmax.py
+++ b/tests/test_dataset_pmax.py
@@ -21,18 +21,20 @@ def test_sliding_window_left_pads_to_pmax():
         pmax_global=5,
     )
 
-    x0, y0 = ds[0]
+    x0, y0, m0 = ds[0]
     assert x0.shape == (5, 1)
     assert y0.shape == (1, 1)
     np.testing.assert_allclose(x0.squeeze(-1).numpy(), np.array([0.0, 0.0, 1.0, 2.0, 3.0], dtype=np.float32))
     np.testing.assert_allclose(y0.squeeze(-1).numpy(), np.array([4.0], dtype=np.float32))
+    np.testing.assert_allclose(m0.squeeze(-1).numpy(), np.array([1.0], dtype=np.float32))
 
-    x_last, _ = ds[len(ds) - 1]
+    x_last, _, m_last = ds[len(ds) - 1]
     assert x_last.shape == (5, 1)
     np.testing.assert_allclose(
         x_last.squeeze(-1).numpy(),
         np.array([2.0, 3.0, 4.0, 5.0, 6.0], dtype=np.float32),
     )
+    np.testing.assert_allclose(m_last.squeeze(-1).numpy(), np.array([1.0], dtype=np.float32))
 
 
 def test_sliding_window_truncates_to_pmax():
@@ -47,10 +49,12 @@ def test_sliding_window_truncates_to_pmax():
         pmax_global=2,
     )
 
-    x0, y0 = ds[0]
+    x0, y0, m0 = ds[0]
     assert x0.shape == (2, 1)
     np.testing.assert_allclose(x0.squeeze(-1).numpy(), np.array([3.0, 4.0], dtype=np.float32))
     np.testing.assert_allclose(y0.squeeze(-1).numpy(), np.array([5.0], dtype=np.float32))
+    np.testing.assert_allclose(m0.squeeze(-1).numpy(), np.array([1.0], dtype=np.float32))
 
-    x1, _ = ds[1]
+    x1, _, m1 = ds[1]
     np.testing.assert_allclose(x1.squeeze(-1).numpy(), np.array([4.0, 5.0], dtype=np.float32))
+    np.testing.assert_allclose(m1.squeeze(-1).numpy(), np.array([1.0], dtype=np.float32))


### PR DESCRIPTION
## Summary
- add valid-mask handling to `SlidingWindowDataset` and propagate masks through dataloader construction
- create loss masks from the raw wide-frame in `train_once`, update `WSMAPELoss`, and apply masked reductions throughout training and evaluation
- add a `use_loss_masking` switch to the default config and adjust unit tests for the new dataset signature

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c8fe8c29888328b906511cc3e05055