### PR TITLE
Keep gaussian NLL loss in float32 under AMP

### DIFF
--- a/src/timesnet_forecast/train.py
+++ b/src/timesnet_forecast/train.py
@@ -47,10 +47,9 @@ def gaussian_nll_loss(
         min_sigma: Optional clamp ensuring strictly positive variance.
 
     Returns:
-        Tensor of per-element losses with the same shape as ``mu``.
+        Tensor of per-element losses with the same shape as ``mu`` stored in
+        ``float32`` precision to preserve numerical stability under AMP.
     """
-
-    orig_dtype = mu.dtype
 
     mu_f32 = mu.to(torch.float32)
     sigma_f32 = sigma.to(torch.float32)
@@ -63,7 +62,7 @@ def gaussian_nll_loss(
     z = (target_f32 - mu_f32) / sigma_f32
     loss_f32 = 0.5 * (z**2 + 2.0 * log_sigma + mu_f32.new_tensor(LOG_2PI))
 
-    return loss_f32.to(orig_dtype)
+    return loss_f32
 
 
 def _select_device(req: str) -> torch.device:


### PR DESCRIPTION
## Summary
- keep `gaussian_nll_loss` in float32 to preserve AMP stability
- document the precision change and add a regression test that covers large residuals

## Testing
- pytest tests/test_gaussian_nll.py

------
https://chatgpt.com/codex/tasks/task_e_68ca5c8674c88328a6dbac6e2f08bc6b