### PR TITLE
Calibrate Gaussian NLL variance floor to target scale

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -33,6 +33,7 @@ train:
   compile: true
   cuda_graphs: false         # Mutually exclusive with compile
   min_sigma: 1.0e-3
+  min_sigma_scale: 0.1       # floor multiplier applied to train target std
   lr_scheduler:
     type: "cosine"
     T_max: ${train.epochs}   # or explicit integer


### PR DESCRIPTION
## Summary
- add a masked standard deviation helper to estimate the dispersion of training targets
- scale the minimum predictive variance using the data-driven std and expose a configurable multiplier
- log and store the effective min_sigma used during training to stabilise Gaussian NLL

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cacc8298708328b2d5ec0a3ddb65bf