### PR TITLE
Propagate period masks through TimesNet

### DIFF
--- a/tests/test_periodicity_transform.py
+++ b/tests/test_periodicity_transform.py
@@ -1,6 +1,7 @@
 import math
 from pathlib import Path
 import sys
+from typing import Tuple
 
 import torch
 import torch.nn.functional as F
@@ -11,43 +12,48 @@ sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
 from timesnet_forecast.models.timesnet import PeriodicityTransform
 
 
-def _periodicity_transform_naive(x: torch.Tensor, k: int) -> torch.Tensor:
+def _periodicity_transform_naive(
+    x: torch.Tensor, k: int, pmax: int
+) -> Tuple[torch.Tensor, torch.Tensor]:
     """Reference implementation using explicit loops for verification."""
     B, T, N = x.shape
-    kidx_list = []
-    Pmax = 1
-    for n in range(N):
-        xn = x[:, :, n]
-        kidx = PeriodicityTransform._topk_freq(xn, k)
-        kidx_list.append(kidx)
-        ch_Pmax = 1
-        for ki in range(kidx.size(1)):
-            f = kidx[:, ki]
-            P = torch.clamp(T // torch.clamp(f, min=1), min=1)
-            ch_Pmax = max(ch_Pmax, int(P.max().item()))
-        Pmax = max(Pmax, ch_Pmax)
-    outs = []
-    for n in range(N):
-        xn = x[:, :, n]
-        kidx = kidx_list[n]
-        mats = []
-        for b in range(B):
-            seq = xn[b]
-            cols = []
-            for ki in range(kidx.size(1)):
-                f = torch.clamp(kidx[b, ki], min=1)
-                P = torch.clamp(T // f, min=1)
-                cycles = torch.clamp(T // P, min=1)
-                take = int((cycles * P).item())
-                seg = seq[-take:].reshape(int(cycles.item()), int(P.item())).mean(dim=0)
-                if P.item() < Pmax:
-                    seg = F.pad(seg, (0, Pmax - int(P.item())))
-                cols.append(seg)
-            if len(cols) == 0:
-                cols = [torch.zeros(Pmax, dtype=seq.dtype)]
-            mats.append(torch.stack(cols, dim=0))
-        outs.append(torch.stack(mats, dim=0))
-    return torch.stack(outs, dim=-1)
+    if k <= 0:
+        empty = x.new_zeros(B, N, 0, pmax)
+        return empty, empty
+
+    seqs = x.permute(0, 2, 1).reshape(B * N, T)
+    kidx = PeriodicityTransform._topk_freq(seqs, k)
+    K = kidx.size(1)
+    if K == 0 or kidx.numel() == 0:
+        empty = x.new_zeros(B, N, 0, pmax)
+        return empty, empty
+
+    kidx = kidx.view(B, N, K)
+    P = torch.clamp(T // torch.clamp(kidx, min=1), min=1)
+    P = torch.clamp(P, min=1, max=pmax)
+    cycles = torch.clamp(T // P, min=1)
+    Cmax = int(torch.clamp(cycles.max(), min=1).item())
+
+    folded = x.new_zeros(B, N, K * Cmax, pmax)
+    mask = torch.zeros_like(folded)
+    for b in range(B):
+        for n in range(N):
+            for ki in range(K):
+                period = int(P[b, n, ki].item())
+                cycle = int(cycles[b, n, ki].item())
+                if period <= 0 or cycle <= 0:
+                    continue
+                take = cycle * period
+                base = max(T - take, 0)
+                slot = ki * Cmax
+                for c in range(Cmax):
+                    for p in range(pmax):
+                        if c < cycle and p < period:
+                            idx = base + c * period + p
+                            idx = min(max(idx, 0), T - 1)
+                            folded[b, n, slot + c, p] = x[b, idx, n]
+                            mask[b, n, slot + c, p] = 1.0
+    return folded, mask
 
 
 def test_periodicity_transform_period_length_consistency():
@@ -63,12 +69,13 @@ def test_periodicity_transform_period_length_consistency():
 
     k = 1
     transform = PeriodicityTransform(k, pmax=T)
-    out = transform(x)
+    folded, mask = transform(x)
 
-    assert out.shape[-1] == N
-    period_len = out.shape[2]
-    for n in range(N):
-        assert out[:, :, :, n].shape[2] == period_len
+    assert folded.shape == mask.shape
+    assert folded.shape[:2] == (B, N)
+    assert folded.shape[-1] == T
+    assert folded.shape[2] % k == 0
+    assert torch.all((mask > 0).any(dim=(2, 3)))
 
 
 def test_periodicity_transform_matches_naive():
@@ -76,10 +83,12 @@ def test_periodicity_transform_matches_naive():
     torch.manual_seed(0)
     B, T, N, k = 3, 64, 4, 3
     x = torch.randn(B, T, N)
-    out_ref = _periodicity_transform_naive(x, k)
-    transform = PeriodicityTransform(k, pmax=out_ref.shape[2])
-    out_vec = transform(x)
+    pmax = T
+    out_ref, mask_ref = _periodicity_transform_naive(x, k, pmax)
+    transform = PeriodicityTransform(k, pmax=pmax)
+    out_vec, mask_vec = transform(x)
     assert torch.allclose(out_vec, out_ref, atol=1e-6)
+    assert torch.allclose(mask_vec, mask_ref, atol=1e-6)
 
 
 def test_periodicity_transform_min_period_threshold_expands_period():
@@ -93,12 +102,14 @@ def test_periodicity_transform_min_period_threshold_expands_period():
     low = FixedFreqTransform(k_periods=1, pmax=10, min_period_threshold=1)
     high = FixedFreqTransform(k_periods=1, pmax=10, min_period_threshold=6)
 
-    out_low = low(x)
-    out_high = high(x)
+    out_low, mask_low = low(x)
+    out_high, mask_high = high(x)
 
     # With the higher minimum period, more slots along P dimension remain populated.
-    nz_low = torch.count_nonzero(out_low.squeeze(0).squeeze(0).squeeze(-1))
-    nz_high = torch.count_nonzero(out_high.squeeze(0).squeeze(0).squeeze(-1))
+    low_active = (mask_low > 0).any(dim=2).squeeze(0).squeeze(0)
+    high_active = (mask_high > 0).any(dim=2).squeeze(0).squeeze(0)
+    nz_low = torch.count_nonzero(low_active)
+    nz_high = torch.count_nonzero(high_active)
 
     assert nz_low.item() == 2  # T // 20 = 2 before applying threshold
     assert nz_high.item() == 6  # Clamped up to the requested minimum
@@ -111,7 +122,7 @@ def test_periodicity_transform_take_gt_T_with_compile():
     x = torch.randn(B, T, N)
 
     class DegenerateTransform(PeriodicityTransform):
-        def forward(self, x: torch.Tensor) -> torch.Tensor:  # type: ignore[override]
+        def forward(self, x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:  # type: ignore[override]
             B, T, N = x.shape
             seqs = x.permute(0, 2, 1).reshape(B * N, T)
             kidx = torch.ones(B * N, self.k, dtype=torch.long, device=x.device)
@@ -139,15 +150,16 @@ def test_periodicity_transform_take_gt_T_with_compile():
 
             mask_c = idx_c.view(1, 1, -1, 1) < cycles[..., None, None]
             mask_p = idx_p.view(1, 1, 1, -1) < P[..., None, None]
-            mask = mask_c & mask_p
+            mask = (mask_c & mask_p).to(gathered.dtype)
             gathered = gathered * mask
 
-            seg = gathered.sum(dim=2) / torch.clamp(cycles[..., None], min=1)
-            seg = seg.view(B, N, K, Pmax).permute(0, 2, 3, 1)
-            return seg
+            gathered = gathered.reshape(B, N, K * gathered.size(2), Pmax)
+            flat_mask = mask.reshape(B, N, K * mask.size(2), Pmax)
+            return gathered, flat_mask
 
     transform = DegenerateTransform(k_periods=1, pmax=T + 2)
     compiled = torch.compile(transform)
-    out = compiled(x)
-    assert out.shape[2] == T + 2
+    folded, mask = compiled(x)
+    assert folded.shape == mask.shape
+    assert folded.shape[-1] == T + 2
 


### PR DESCRIPTION
## Summary
- update `PeriodicityTransform` to return both flattened cycle tensors and matching masks
- adapt `TimesNet` to consume the new tuple, keep padded positions zeroed, and resize its input projection when cycles grow
- refresh periodicity transform tests (including the naive reference) to reflect the new tensor-plus-mask contract

## Testing
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_68cb4c0d8ee08328bda70afac24742fd