### PR TITLE
Support per-series min sigma floors

### DIFF
--- a/tests/test_gaussian_nll.py
+++ b/tests/test_gaussian_nll.py
@@ -35,6 +35,23 @@ def test_gaussian_nll_respects_min_sigma():
     assert torch.allclose(loss_clamped, loss_reference)
 
 
+def test_gaussian_nll_tensor_min_sigma_clamps_each_series():
+    mu = torch.zeros((1, 1, 3), dtype=torch.float32)
+    sigma = torch.full((1, 1, 3), 1e-4, dtype=torch.float32)
+    target = torch.zeros((1, 1, 3), dtype=torch.float32)
+
+    min_sigma = torch.tensor([[[1.0, 0.5, 2.5]]], dtype=torch.float32)
+    loss_tensor = gaussian_nll_loss(mu, sigma, target, min_sigma=min_sigma)
+
+    clamped = min_sigma
+    manual = 0.5 * (
+        ((target - mu) / clamped) ** 2
+        + 2.0 * torch.log(clamped)
+        + math.log(2.0 * math.pi)
+    )
+    assert torch.allclose(loss_tensor, manual)
+
+
 def test_gaussian_nll_autocast_stability():
     device = "cuda" if torch.cuda.is_available() else "cpu"
     if device == "cuda":

--- a/tests/test_timesnet_forward.py
+++ b/tests/test_timesnet_forward.py
@@ -42,3 +42,29 @@ def test_forward_shape_and_head_processing():
     mu_head, sigma_head = model(long_x[:, :L, :])
     assert mu_long.shape == mu_head.shape == (B, H, N)
     assert sigma_long.shape == sigma_head.shape == (B, H, N)
+
+
+def test_timesnet_applies_per_series_floor():
+    B, L, H, N = 1, 12, 3, 4
+    floor = torch.tensor([0.05, 0.1, 0.2, 0.3], dtype=torch.float32)
+
+    model = TimesNet(
+        input_len=L,
+        pred_len=H,
+        d_model=8,
+        n_layers=1,
+        k_periods=1,
+        pmax=L,
+        kernel_set=[3],
+        dropout=0.0,
+        activation="gelu",
+        mode="direct",
+        min_sigma_vector=floor,
+    )
+    with torch.no_grad():
+        model(torch.zeros(1, L, N))
+
+    x = torch.randn(B, L, N)
+    _, sigma = model(x)
+    expected_floor = floor.view(1, 1, N)
+    assert torch.all(sigma >= expected_floor)


### PR DESCRIPTION
## Summary
- extend min sigma calibration to return per-series statistics and propagate them into training
- allow TimesNet and gaussian_nll_loss to apply tensor-valued minimum sigma floors
- expand tests to cover per-series clamping behaviour and the new min sigma outputs

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb6ccf2ee88328bdd7e540e9a3e49f