### PR TITLE
Warm-up inference model before loading state

### DIFF
--- a/src/timesnet_forecast/predict.py
+++ b/src/timesnet_forecast/predict.py
@@ -116,9 +116,10 @@ def predict_once(cfg: Dict) -> str:
     ).to(device)
     # Lazily construct layers by mirroring the training warm-up.
     with torch.no_grad():
+        warmup_len = int(cfg_used["model"]["pmax"])
         dummy = torch.zeros(
             1,
-            int(cfg_used["model"]["input_len"]),
+            warmup_len,
             len(ids),
             device=device,
         )


### PR DESCRIPTION
## Summary
- warm up the prediction model by running a zero batch through it under `torch.no_grad()` so lazy layers match training
- keep the channels-last memory format adjustment and load checkpoints with `strict=True`
- size the warm-up batch to the training `pmax` so lazy modules expand to the same shapes as the checkpoint

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb8592f78083288c655898393218cd