### PR TITLE
Handle min_sigma_vector in predict state loading

### DIFF
--- a/src/timesnet_forecast/predict.py
+++ b/src/timesnet_forecast/predict.py
@@ -142,6 +142,7 @@ def predict_once(cfg: Dict) -> str:
                 device=model.blocks[0].weight.device,
                 dtype=model.blocks[0].weight.dtype,
             )
+    clean_state.pop("min_sigma_vector", None)
     model.load_state_dict(clean_state, strict=True)
     if cfg_used["train"]["channels_last"]:
         model.to(memory_format=torch.channels_last)


### PR DESCRIPTION
## Summary
- drop the `min_sigma_vector` entry from prediction checkpoint states before loading
- load the cleaned state dict with strict=True to avoid buffer conflicts

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb8bbcbd4883288478d48004adfd41