### PR TITLE
Handle min_sigma_vector when loading checkpoints

### DIFF
--- a/src/timesnet_forecast/predict.py
+++ b/src/timesnet_forecast/predict.py
@@ -142,7 +142,14 @@ def predict_once(cfg: Dict) -> str:
                 device=model.blocks[0].weight.device,
                 dtype=model.blocks[0].weight.dtype,
             )
-    clean_state.pop("min_sigma_vector", None)
+    min_sigma_buffer = getattr(model, "min_sigma_vector", None)
+    if isinstance(min_sigma_buffer, torch.Tensor) and min_sigma_buffer.numel() > 0:
+        checkpoint_value = clean_state.get("min_sigma_vector")
+        buffer_cpu = min_sigma_buffer.detach().to("cpu")
+        if isinstance(checkpoint_value, torch.Tensor):
+            buffer_cpu = buffer_cpu.to(dtype=checkpoint_value.dtype)
+        if not isinstance(checkpoint_value, torch.Tensor):
+            clean_state["min_sigma_vector"] = buffer_cpu
     model.load_state_dict(clean_state, strict=True)
     if cfg_used["train"]["channels_last"]:
         model.to(memory_format=torch.channels_last)

--- a/src/timesnet_forecast/predict.py
+++ b/src/timesnet_forecast/predict.py
@@ -150,6 +150,8 @@ def predict_once(cfg: Dict) -> str:
             buffer_cpu = buffer_cpu.to(dtype=checkpoint_value.dtype)
         if not isinstance(checkpoint_value, torch.Tensor):
             clean_state["min_sigma_vector"] = buffer_cpu
+    else:
+        clean_state.pop("min_sigma_vector", None)
     model.load_state_dict(clean_state, strict=True)
     if cfg_used["train"]["channels_last"]:
         model.to(memory_format=torch.channels_last)


### PR DESCRIPTION
## Summary
- ensure `predict.py` retains the `min_sigma_vector` buffer when loading checkpoints by inserting a CPU copy when required

## Testing
- pytest tests/test_timesnet_forward.py

------
https://chatgpt.com/codex/tasks/task_e_68cb8ed8bb6883288a4c45debd4c2a09