### PR TITLE
Ensure min sigma vector buffer overrides checkpoint entry

### DIFF
--- a/src/timesnet_forecast/predict.py
+++ b/src/timesnet_forecast/predict.py
@@ -148,8 +148,7 @@ def predict_once(cfg: Dict) -> str:
         buffer_cpu = min_sigma_buffer.detach().to("cpu")
         if isinstance(checkpoint_value, torch.Tensor):
             buffer_cpu = buffer_cpu.to(dtype=checkpoint_value.dtype)
-        if not isinstance(checkpoint_value, torch.Tensor):
-            clean_state["min_sigma_vector"] = buffer_cpu
+        clean_state["min_sigma_vector"] = buffer_cpu
     else:
         clean_state.pop("min_sigma_vector", None)
     model.load_state_dict(clean_state, strict=True)


### PR DESCRIPTION
## Summary
- ensure the loaded checkpoint always receives the model's min_sigma_vector buffer when present
- keep removing the checkpoint entry when the model lacks a per-series floor
- continue loading the state dict strictly to enforce key alignment

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb944bbbf08328afd6eb000e43794b