### PR TITLE
Handle history masks through FFT pipeline

### DIFF
--- a/tests/test_dataset_pmax.py
+++ b/tests/test_dataset_pmax.py
@@ -1,5 +1,5 @@
-import sys
 from pathlib import Path
+import sys
 
 import numpy as np
 import pytest
@@ -22,20 +22,28 @@ def test_sliding_window_left_pads_to_pmax():
         pmax_global=5,
     )
 
-    x0, y0, m0 = ds[0]
+    x0, y0, m0, hist0 = ds[0]
     assert x0.shape == (5, 1)
     assert y0.shape == (1, 1)
     np.testing.assert_allclose(x0.squeeze(-1).numpy(), np.array([0.0, 0.0, 1.0, 2.0, 3.0], dtype=np.float32))
     np.testing.assert_allclose(y0.squeeze(-1).numpy(), np.array([4.0], dtype=np.float32))
     np.testing.assert_allclose(m0.squeeze(-1).numpy(), np.array([1.0], dtype=np.float32))
+    np.testing.assert_allclose(
+        hist0.squeeze(-1).numpy(),
+        np.array([0.0, 0.0, 1.0, 1.0, 1.0], dtype=np.float32),
+    )
 
-    x_last, _, m_last = ds[len(ds) - 1]
+    x_last, _, m_last, hist_last = ds[len(ds) - 1]
     assert x_last.shape == (5, 1)
     np.testing.assert_allclose(
         x_last.squeeze(-1).numpy(),
         np.array([2.0, 3.0, 4.0, 5.0, 6.0], dtype=np.float32),
     )
     np.testing.assert_allclose(m_last.squeeze(-1).numpy(), np.array([1.0], dtype=np.float32))
+    np.testing.assert_allclose(
+        hist_last.squeeze(-1).numpy(),
+        np.ones(5, dtype=np.float32),
+    )
 
 
 def test_sliding_window_requires_pmax_at_least_input_len():

--- a/tests/test_dummy_training.py
+++ b/tests/test_dummy_training.py
@@ -91,7 +91,9 @@ def test_eval_metrics_returns_masked_nll():
             self.register_buffer("sigma_buf", sigma)
             self.period = SimpleNamespace(pmax=1)
 
-        def forward(self, x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        def forward(
+            self, x: torch.Tensor, mask: torch.Tensor | None = None
+        ) -> tuple[torch.Tensor, torch.Tensor]:
             batch = x.shape[0]
             mu = self.mu_buf.expand(batch, -1, -1)
             sigma = self.sigma_buf.expand(batch, -1, -1)
@@ -99,7 +101,8 @@ def test_eval_metrics_returns_masked_nll():
 
     model = DummyModel(mu, sigma)
     xb = torch.zeros((1, 3, 2), dtype=torch.float32)
-    loader = [(xb, target, mask)]
+    hist_mask = torch.ones_like(xb)
+    loader = [(xb, target, mask, hist_mask)]
     metrics = _eval_metrics(
         model,
         loader,

--- a/tests/test_global_pmax.py
+++ b/tests/test_global_pmax.py
@@ -219,7 +219,7 @@ def test_short_periods_clamped_to_input_len(tmp_path):
         pmax_global=int(cfg["model"]["pmax"]),
     )
 
-    xb, _, _ = next(iter(dl))
+    xb, _, _, _ = next(iter(dl))
     assert xb.shape[1] == input_len
     assert xb.shape[1] == int(cfg["model"]["pmax"])
 


### PR DESCRIPTION
## Summary
- extend the sliding window dataset to emit a padded history mask aligned with each input window and validate mask padding
- ensure the PeriodicityTransform and TimesNet forward paths accept optional history masks, ignore padded prefixes, and propagate fold masks
- thread history masks through training, validation, and inference utilities and cover the new behavior with unit tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cba636166883288350ed63b82b00c0