### PR TITLE
Add period group chunk heuristics and tests

### DIFF
--- a/src/timesnet_forecast/train.py
+++ b/src/timesnet_forecast/train.py
@@ -612,6 +612,9 @@ def train_once(cfg: Dict) -> Tuple[float, Dict]:
         use_checkpoint=use_checkpoint,
         min_sigma=min_sigma_scalar,
         min_sigma_vector=min_sigma_vector_tensor,
+        period_group_chunk=cfg["model"].get("period_group_chunk"),
+        period_group_memory_ratio=cfg["model"].get("period_group_memory_ratio"),
+        period_group_max_chunk_bytes=cfg["model"].get("period_group_max_chunk_bytes"),
     ).to(device)
 
     # Lazily build model parameters so that downstream utilities see them


### PR DESCRIPTION
## Summary
- add configurable period-group chunking controls to TimesNet, including GPU/CPU memory heuristics
- surface the new knobs from the training configuration when building the model
- extend the forward pass tests with a regression that covers the chunk heuristic

## Testing
- pytest tests/test_timesnet_forward.py

------
https://chatgpt.com/codex/tasks/task_e_68cbfd0aa80c8328833cc099714d3df3