### PR TITLE
Disable cuDNN benchmark by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 - Configuration option `model.inception_kernel_set` has been renamed to `model.kernel_set`. The previous name is still accepted for backward compatibility.
 - Using CUDA Graphs (`train.cuda_graphs: true`) disables dropout because the model is placed in evaluation mode during graph capture. This trades regularization for faster execution.
 - Activation checkpointing can be toggled via `train.use_checkpoint`. Enabling it reduces memory usage at the cost of slower training throughput and is automatically turned off when CUDA graphs are active.
+- cuDNN benchmarking is disabled by default to keep memory usage stable across the many chunk shapes produced by TimesNet. Set `train.cudnn_benchmark: true` to opt into the higher-workspace algorithm search when you have sufficient GPU headroom.
 - Manual CUDA graph capture (`train.cuda_graphs`) and `torch.compile` (`train.compile`) are mutually exclusive. TorchDynamo already performs graph capture and its compiled modules cannot be re-captured safely.
 - `model.pmax_cap` limits the automatically inferred maximum period length. During training the dominant period across all series is detected and then clipped to this cap to avoid extremely long seasonal windows.
 - The model "telescopes" input sequences: `TimesNet.forward` always crops to the first `input_len` steps of the periodic canvas, so passing extra history at inference produces the same `[B, pred_len, N]` shaped output as training.

--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -31,6 +31,7 @@ train:
   grad_clip_norm: 1.0
   amp: true
   compile: false
+  cudnn_benchmark: false       # Enable only if you want cuDNN to search for high-workspace kernels
   cuda_graphs: false         # Mutually exclusive with compile
   use_checkpoint: false      # Enable activation checkpointing to save memory at the cost of speed
   min_sigma: 1.0e-3

--- a/src/timesnet_forecast/dependency.py
+++ b/src/timesnet_forecast/dependency.py
@@ -11,7 +11,8 @@ def bootstrap(cfg: dict) -> torch.device:
     if want == "cuda" and not torch.cuda.is_available():
         console().print("[yellow]CUDA not available; falling back to CPU.[/yellow]")
     device = torch.device("cuda:0" if (want == "cuda" and torch.cuda.is_available()) else "cpu")
-    torch.backends.cudnn.benchmark = True
+    cudnn_benchmark = bool(cfg["train"].get("cudnn_benchmark", False))
+    torch.backends.cudnn.benchmark = bool(device.type == "cuda" and cudnn_benchmark)
     torch.set_float32_matmul_precision(cfg["train"]["matmul_precision"])
     seed_everything(int(cfg.get("tuning", {}).get("seed", 2025)))
     return device

--- a/src/timesnet_forecast/predict.py
+++ b/src/timesnet_forecast/predict.py
@@ -77,7 +77,8 @@ def predict_once(cfg: Dict) -> str:
             cfg_used[k] = v
 
     device = _select_device(cfg_used["train"]["device"])
-    torch.backends.cudnn.benchmark = True
+    cudnn_benchmark = bool(cfg_used["train"].get("cudnn_benchmark", False))
+    torch.backends.cudnn.benchmark = bool(device.type == "cuda" and cudnn_benchmark)
     torch.set_float32_matmul_precision(cfg_used["train"]["matmul_precision"])
     console().print(f"[bold green]Predict device:[/bold green] {device}")
 

--- a/src/timesnet_forecast/train.py
+++ b/src/timesnet_forecast/train.py
@@ -435,7 +435,8 @@ def _eval_metrics(
 def train_once(cfg: Dict) -> Tuple[float, Dict]:
     # --- bootstrap
     device = _select_device(cfg["train"]["device"])
-    torch.backends.cudnn.benchmark = True
+    cudnn_benchmark = bool(cfg["train"].get("cudnn_benchmark", False))
+    torch.backends.cudnn.benchmark = bool(device.type == "cuda" and cudnn_benchmark)
     torch.set_float32_matmul_precision(cfg["train"]["matmul_precision"])
     seed_everything(int(cfg.get("tuning", {}).get("seed", 2025)))
     console().print(f"[bold green]Device:[/bold green] {device}")


### PR DESCRIPTION
## Summary
- gate cuDNN benchmark behind a new `train.cudnn_benchmark` flag and respect it when bootstrapping training, dependency checks, and prediction
- document the new default and surface the option in the configuration template so users can opt in when desired

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ccd667ee688328b041238485e4839e