### PR TITLE
Pin period groups on CPU and stream tiles to the model

### DIFF
--- a/tests/test_periodicity_transform.py
+++ b/tests/test_periodicity_transform.py
@@ -317,6 +317,8 @@ def test_periodicity_transform_take_gt_T_with_compile():
                 frequency_indices=freq_idx,
                 cycles=1,
                 period=self.pmax,
+                source_device=values.device,
+                source_dtype=values.dtype,
             )
             return [group]
 

--- a/tests/test_timesnet_forward.py
+++ b/tests/test_timesnet_forward.py
@@ -272,6 +272,8 @@ def test_period_group_chunk_helper_caps_size(monkeypatch):
         frequency_indices=freq_indices,
         cycles=cycles,
         period=period,
+        source_device=values.device,
+        source_dtype=values.dtype,
     )
 
     monkeypatch.setattr(model.period, "forward", lambda *args, **kwargs: [fake_group])
@@ -287,7 +289,12 @@ def test_period_group_chunk_helper_caps_size(monkeypatch):
             mu_full, sigma_full = model(x)
 
             model.period_group_chunk = None
-            chunk_size = model._resolve_period_group_chunk(fake_group, dtype=dtype)
+            frontend_param = next(iter(model.frontend.parameters()), None)
+            target_device = frontend_param.device if frontend_param is not None else x.device
+            chunk_size = model._resolve_period_group_chunk(
+                fake_group,
+                target_device=target_device,
+            )
             assert chunk_size < tile_count
 
             mu_chunk, sigma_chunk = model(x)
@@ -331,6 +338,8 @@ def test_period_group_chunks_shrink_with_budget(monkeypatch):
         frequency_indices=freq_indices,
         cycles=cycles,
         period=period,
+        source_device=values.device,
+        source_dtype=values.dtype,
     )
 
     monkeypatch.setattr(model.period, "forward", lambda *args, **kwargs: [fake_group])


### PR DESCRIPTION
## Summary
- add source device/dtype metadata to PeriodGroup and move tiles into pinned CPU memory during grouping
- update chunk size estimation to rely on the stored dtype and the target execution device
- stream period tiles back to the frontend device/dtype with non-blocking copies and refresh the unit tests

## Testing
- pytest tests/test_timesnet_forward.py tests/test_periodicity_transform.py

------
https://chatgpt.com/codex/tasks/task_e_68ccdb2f9e688328a97557c798589a2c