### PR TITLE
Add checkpointed period group recompute path

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -65,6 +65,7 @@ model:
   min_period_threshold: 7  # 최소 주기 하한선
   kernel_set: [3, 5, 7]
   activation: "gelu"
+  period_group_recompute: null  # defaults to True on CUDA devices
 
 tuning:
   enabled: true

--- a/src/timesnet_forecast/predict.py
+++ b/src/timesnet_forecast/predict.py
@@ -126,6 +126,7 @@ def predict_once(cfg: Dict) -> str:
         use_checkpoint=use_checkpoint,
         min_sigma=min_sigma_scalar,
         min_sigma_vector=min_sigma_vector_tensor,
+        period_group_recompute=cfg_used["model"].get("period_group_recompute"),
     ).to(device)
     # Lazily construct layers by mirroring the training warm-up.
     with torch.no_grad():

--- a/src/timesnet_forecast/train.py
+++ b/src/timesnet_forecast/train.py
@@ -615,6 +615,7 @@ def train_once(cfg: Dict) -> Tuple[float, Dict]:
         period_group_chunk=cfg["model"].get("period_group_chunk"),
         period_group_memory_ratio=cfg["model"].get("period_group_memory_ratio"),
         period_group_max_chunk_bytes=cfg["model"].get("period_group_max_chunk_bytes"),
+        period_group_recompute=cfg["model"].get("period_group_recompute"),
     ).to(device)
 
     # Lazily build model parameters so that downstream utilities see them


### PR DESCRIPTION
## Summary
- add a `period_group_recompute` flag (defaulting on for CUDA) and move the per-chunk folding work into a reusable helper
- wrap the helper with activation checkpointing when chunk recompute is enabled so backward always replays the chunk without storing activations
- plumb the new flag through config/train/predict and add a CUDA stress test that checks VRAM stays bounded across chunks

## Testing
- pytest tests/test_timesnet_forward.py

------
https://chatgpt.com/codex/tasks/task_e_68cceda202bc8328b24a345ad428ce43