### PR TITLE
Optimize period tile transfers

### DIFF
--- a/tests/test_timesnet_forward.py
+++ b/tests/test_timesnet_forward.py
@@ -456,6 +456,7 @@ def test_period_group_chunk_helper_caps_size(monkeypatch):
             chunk_size = model._resolve_period_group_chunk(
                 fake_group,
                 target_device=target_device,
+                target_dtype=dtype,
             )
             assert chunk_size < tile_count
 


### PR DESCRIPTION
## Summary
- keep PeriodicityTransform tiles on their source device unless CPU staging is required
- plumb target dtype awareness through _resolve_period_group_chunk and skip redundant tensor.to() copies in TimesNet.forward
- update the chunking unit test to pass the new dtype hint

## Testing
- pytest tests/test_timesnet_forward.py
- PYTHONPATH=src python -m timesnet_forecast.train --config configs/default.yaml --override train.epochs=1 train.batch_size=64 train.num_workers=2 train.persistent_workers=false train.pin_memory=false model.d_model=16 model.n_layers=0 model.k_periods=1 model.pmax_cap=64 model.min_period_threshold=4


------
https://chatgpt.com/codex/tasks/task_e_68cd04dedb6083289fdd3eceaed6d40d