### PR TITLE
Add FFT amplitude weighting to TimesBlock

### DIFF
--- a/src/timesnet_forecast/train.py
+++ b/src/timesnet_forecast/train.py
@@ -167,7 +167,7 @@ def _compute_pmax_global(arrays: List[np.ndarray], k: int, cap: int) -> int:
         if arr.size == 0:
             continue
         x = torch.from_numpy(arr.T.astype(np.float32))  # [N, T]
-        kidx = PeriodicityTransform._topk_freq(x, k)
+        kidx, _ = PeriodicityTransform._topk_freq(x, k)
         if kidx.numel() == 0:
             continue
         periods = torch.clamp(x.shape[-1] // torch.clamp(kidx, min=1), min=1)


### PR DESCRIPTION
## Summary
- return FFT amplitudes alongside frequency indices from `PeriodicityTransform`
- propagate the amplitudes into TimesBlock and apply softmax-normalised weighting to the per-period reconstructions
- update callers and tests to handle the additional amplitude output

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cfe75f5e4c83288b66d32ba2d1deaa