### PR TITLE
Add optional embedding layer normalization toggle

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -67,6 +67,7 @@ model:
     - [5, 5]
     - [7, 7]
   activation: "gelu"
+  use_embedding_norm: true
 
 tuning:
   enabled: true

--- a/src/timesnet_forecast/predict.py
+++ b/src/timesnet_forecast/predict.py
@@ -99,6 +99,7 @@ def predict_once(cfg: Dict) -> str:
         mode=str(cfg_used["model"]["mode"]),
         channels_last=cfg_used["train"]["channels_last"],
         use_checkpoint=use_checkpoint,
+        use_embedding_norm=bool(cfg_used["model"].get("use_embedding_norm", True)),
         min_sigma=min_sigma_scalar,
         min_sigma_vector=min_sigma_vector_tensor,
     ).to(device)

--- a/src/timesnet_forecast/train.py
+++ b/src/timesnet_forecast/train.py
@@ -570,6 +570,7 @@ def train_once(cfg: Dict) -> Tuple[float, Dict]:
         mode=mode,
         channels_last=cfg["train"]["channels_last"],
         use_checkpoint=use_checkpoint,
+        use_embedding_norm=bool(cfg["model"].get("use_embedding_norm", True)),
         min_sigma=min_sigma_scalar,
         min_sigma_vector=min_sigma_vector_tensor,
     ).to(device)


### PR DESCRIPTION
## Summary
- add a LayerNorm stage inside the TimesNet DataEmbedding module with an opt-in flag
- thread the new `model.use_embedding_norm` setting through TimesNet, training, and prediction configs
- enable the toggle by default in the base configuration file

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d0c2a34c648328b0c8d42b44d8dcc8