### PR TITLE
Adjust TimesBlock residual aggregation to use raw convolution outputs

### DIFF
--- a/src/timesnet_forecast/models/timesnet.py
+++ b/src/timesnet_forecast/models/timesnet.py
@@ -241,12 +241,11 @@ class TimesBlock(nn.Module):
             cycles = total_len // period
             grid = x_pad.view(B, C, cycles, period)
             conv_out = self.inception(grid)
-            delta = conv_out - grid
-            delta = delta.view(B, C, total_len)
-            delta = delta.permute(0, 2, 1)
+            conv_out = conv_out.view(B, C, total_len)
+            conv_out = conv_out.permute(0, 2, 1)
             if pad_len > 0:
-                delta = delta[:, :-pad_len, :]
-            residuals.append(delta)
+                conv_out = conv_out[:, :-pad_len, :]
+            residuals.append(conv_out)
             valid_indices.append(idx)
 
         if not residuals:

--- a/tests/test_times_block.py
+++ b/tests/test_times_block.py
@@ -63,11 +63,10 @@ def _reference_times_block(
         cycles = total_len // period
         grid = x_pad.view(B, C, cycles, period)
         conv_out = block.inception(grid)
-        delta = conv_out - grid
-        delta = delta.view(B, C, total_len).permute(0, 2, 1)
+        conv_out = conv_out.view(B, C, total_len).permute(0, 2, 1)
         if pad_len > 0:
-            delta = delta[:, :-pad_len, :]
-        residuals.append(delta)
+            conv_out = conv_out[:, :-pad_len, :]
+        residuals.append(conv_out)
         valid_indices.append(idx)
 
     if not residuals:


### PR DESCRIPTION
## Summary
- update TimesBlock to aggregate weighted convolution outputs directly instead of subtracting the input grid
- align the times_block reference helper to the new behavior for softmax weighting tests

## Testing
- pytest tests/test_times_block.py::test_times_block_matches_reference_impl

------
https://chatgpt.com/codex/tasks/task_e_68d10570219883288e8d2a21ea75d0b5