### PR TITLE
Apply layer norm after each TimesBlock

### DIFF
--- a/src/timesnet_forecast/models/timesnet.py
+++ b/src/timesnet_forecast/models/timesnet.py
@@ -501,8 +501,7 @@ class TimesNet(nn.Module):
                 updated = block(features)
             delta = updated - features
             features = features + self.residual_dropout(delta)
-
-        features = self.layer_norm(features)
+            features = self.layer_norm(features)
         target_features = features[:, -target_steps:, :].contiguous()
         mu = self.output_proj(target_features)  # type: ignore[operator]
         assert self.sigma_proj is not None  # for type checkers


### PR DESCRIPTION
## Summary
- normalize TimesNet residual features after every block by reusing the existing layer norm instead of a single post-loop call

## Testing
- `PYTHONPATH=src python -m timesnet_forecast.cli train --override train.device=cpu train.epochs=1 train.lr_warmup_steps=0 train.batch_size=4 train.num_workers=1 train.pin_memory=false train.persistent_workers=false train.use_checkpoint=false train.cuda_graphs=false train.amp=false train.channels_last=false train.val.strategy=holdout model.d_model=64 model.d_ff=128 model.n_layers=2`


------
https://chatgpt.com/codex/tasks/task_e_68d1192ae28c83288ee35151108dedd7