### PR TITLE
Add configurable bottleneck ratio for TimesNet inception blocks

### DIFF
--- a/src/timesnet_forecast/models/timesnet.py
+++ b/src/timesnet_forecast/models/timesnet.py
@@ -200,6 +200,7 @@ class TimesBlock(nn.Module):
         dropout: float,
         activation: str,
         d_ff: int | None = None,
+        bottleneck_ratio: float = 1.0,
     ) -> None:
         super().__init__()
         self.d_model = int(d_model)
@@ -208,6 +209,9 @@ class TimesBlock(nn.Module):
         self.d_ff = int(d_ff)
         if self.d_ff <= 0:
             raise ValueError("d_ff must be a positive integer")
+        self.bottleneck_ratio = float(bottleneck_ratio)
+        if self.bottleneck_ratio <= 0:
+            raise ValueError("bottleneck_ratio must be a positive value")
 
         act_name = activation.lower()
         if act_name == "relu":
@@ -223,6 +227,7 @@ class TimesBlock(nn.Module):
                 kernel_set=kernel_spec,
                 dropout=dropout,
                 act=activation,
+                bottleneck_ratio=self.bottleneck_ratio,
             ),
             mid_activation,
             InceptionBlock(
@@ -231,6 +236,7 @@ class TimesBlock(nn.Module):
                 kernel_set=kernel_spec,
                 dropout=dropout,
                 act=activation,
+                bottleneck_ratio=self.bottleneck_ratio,
             ),
         )
         # ``period_selector`` is injected from ``TimesNet`` after instantiation to
@@ -380,6 +386,7 @@ class TimesNet(nn.Module):
         activation: str,
         mode: str,
         d_ff: int | None = None,
+        bottleneck_ratio: float = 1.0,
         min_period_threshold: int = 1,
         channels_last: bool = False,
         use_checkpoint: bool = True,
@@ -399,6 +406,9 @@ class TimesNet(nn.Module):
         self.d_ff = int(d_ff)
         if self.d_ff <= 0:
             raise ValueError("d_ff must be a positive integer")
+        self.bottleneck_ratio = float(bottleneck_ratio)
+        if self.bottleneck_ratio <= 0:
+            raise ValueError("bottleneck_ratio must be a positive value")
         self.n_layers = int(n_layers)
         self.dropout = float(dropout)
         self.use_checkpoint = bool(use_checkpoint)
@@ -419,6 +429,7 @@ class TimesNet(nn.Module):
                     kernel_set=self.kernel_set,
                     dropout=self.dropout,
                     activation=activation,
+                    bottleneck_ratio=self.bottleneck_ratio,
                 )
                 for _ in range(self.n_layers)
             ]

--- a/src/timesnet_forecast/predict.py
+++ b/src/timesnet_forecast/predict.py
@@ -90,6 +90,8 @@ def predict_once(cfg: Dict) -> str:
     d_model = int(model_cfg["d_model"])
     d_ff = int(model_cfg.get("d_ff", 4 * d_model))
     model_cfg["d_ff"] = d_ff
+    bottleneck_ratio = float(model_cfg.get("bottleneck_ratio", 1.0))
+    model_cfg["bottleneck_ratio"] = bottleneck_ratio
 
     model = TimesNet(
         input_len=input_len,
@@ -103,6 +105,7 @@ def predict_once(cfg: Dict) -> str:
         dropout=float(model_cfg["dropout"]),
         activation=str(model_cfg["activation"]),
         mode=str(model_cfg["mode"]),
+        bottleneck_ratio=bottleneck_ratio,
         channels_last=cfg_used["train"]["channels_last"],
         use_checkpoint=use_checkpoint,
         use_embedding_norm=bool(model_cfg.get("use_embedding_norm", True)),

--- a/src/timesnet_forecast/train.py
+++ b/src/timesnet_forecast/train.py
@@ -561,6 +561,8 @@ def train_once(cfg: Dict) -> Tuple[float, Dict]:
     d_model = int(model_cfg["d_model"])
     d_ff = int(model_cfg.get("d_ff", 4 * d_model))
     model_cfg["d_ff"] = d_ff
+    bottleneck_ratio = float(model_cfg.get("bottleneck_ratio", 1.0))
+    model_cfg["bottleneck_ratio"] = bottleneck_ratio
 
     model = TimesNet(
         input_len=input_len,
@@ -574,6 +576,7 @@ def train_once(cfg: Dict) -> Tuple[float, Dict]:
         dropout=float(model_cfg["dropout"]),
         activation=str(model_cfg["activation"]),
         mode=mode,
+        bottleneck_ratio=bottleneck_ratio,
         channels_last=cfg["train"]["channels_last"],
         use_checkpoint=use_checkpoint,
         use_embedding_norm=bool(model_cfg.get("use_embedding_norm", True)),


### PR DESCRIPTION
## Summary
- add a bottleneck_ratio option to TimesBlock/TimesNet and forward it to both inception stages
- allow training and prediction entrypoints to read the bottleneck_ratio from model configs so YAML/CLI overrides continue to work

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d155d2c0048328be48f8e48867b095