### PR TITLE
Add tests and docs for InceptionBlock bottleneck ratio

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@
   stability. Validation uses the mean Gaussian NLL for model selection while still reporting
   SMAPE as a secondary diagnostic metric.
 - Configuration option `model.inception_kernel_set` has been renamed to `model.kernel_set`. The previous name is still accepted for backward compatibility.
+- `model.bottleneck_ratio` toggles ``1×1 → k×k → 1×1`` bottlenecks inside every inception branch.
+  Ratios greater than ``1`` shrink the hidden width while ratios below ``1`` expand it; set the
+  value to ``1.0`` to recover the previous single ``k×k`` convolution without bottlenecks.
 - Using CUDA Graphs (`train.cuda_graphs: true`) disables dropout because the model is placed in evaluation mode during graph capture. This trades regularization for faster execution.
 - Activation checkpointing can be toggled via `train.use_checkpoint`. Enabling it reduces memory usage at the cost of slower training throughput and is automatically turned off when CUDA graphs are active.
 - Manual CUDA graph capture (`train.cuda_graphs`) and `torch.compile` (`train.compile`) are mutually exclusive. TorchDynamo already performs graph capture and its compiled modules cannot be re-captured safely.

--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -69,6 +69,7 @@ model:
     - [5, 5]
     - [7, 7]
   activation: "gelu"
+  bottleneck_ratio: 1.0      # Controls 1x1→kxk→1x1 bottlenecks; values ≠1 enable them
   use_embedding_norm: true
 
 tuning:

--- a/tests/test_inception_block.py
+++ b/tests/test_inception_block.py
@@ -1,0 +1,44 @@
+import sys
+from pathlib import Path
+
+import pytest
+import torch
+
+# Ensure the project src is on the path for imports
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from timesnet_forecast.models.timesnet import InceptionBlock
+
+
+@pytest.mark.parametrize(
+    "in_ch,out_ch,bottleneck_ratio",
+    [
+        (8, 8, 0.5),
+        (4, 6, 2.0),
+    ],
+)
+def test_inception_block_bottleneck_residual(in_ch, out_ch, bottleneck_ratio):
+    block = InceptionBlock(
+        in_ch=in_ch,
+        out_ch=out_ch,
+        kernel_set=[(3, 3), (5, 1)],
+        dropout=0.0,
+        act="gelu",
+        bottleneck_ratio=bottleneck_ratio,
+    )
+
+    with torch.no_grad():
+        x = torch.randn(2, in_ch, 5, 7)
+        out = block(x)
+
+    assert out.shape == (2, out_ch, 5, 7)
+
+    with torch.no_grad():
+        residual = block.res_proj(x)
+        branch_outputs = [path(x) for path in block.paths]
+        merged = torch.cat(branch_outputs, dim=1)
+        projected = block.proj(merged)
+        activated = block.act(projected)
+        dropped = block.dropout(activated)
+
+    assert torch.allclose(out, dropped + residual)


### PR DESCRIPTION
## Summary
- add a dedicated unit test that exercises InceptionBlock with non-trivial bottleneck ratios and validates residual behaviour
- document the model.bottleneck_ratio hyperparameter in the README and surface it in the default configuration file

## Testing
- pytest
- PYTHONPATH=src python -m timesnet_forecast.train --config configs/default.yaml --override train.epochs=0 train.num_workers=1
- PYTHONPATH=src python -m timesnet_forecast.predict --config configs/default.yaml

------
https://chatgpt.com/codex/tasks/task_e_68d1589856c48328a796b0b0cbc22dec