### PR TITLE
Use ceiling periods and test TimesBlock round-trip

### DIFF
--- a/src/timesnet_forecast/models/timesnet.py
+++ b/src/timesnet_forecast/models/timesnet.py
@@ -92,7 +92,12 @@ class FFTPeriodSelector(nn.Module):
         )
         indices = torch.clamp(indices, min=1)
 
-        periods = torch.div(L, indices, rounding_mode="floor")
+        try:
+            periods = torch.div(L, indices, rounding_mode="ceil")
+        except RuntimeError as exc:  # pragma: no cover - fallback for older PyTorch
+            if "rounding_mode" not in str(exc):
+                raise
+            periods = torch.div(-L, indices, rounding_mode="floor").neg()
         periods = periods.to(torch.long)
         periods = torch.clamp(
             periods,


### PR DESCRIPTION
## Summary
- switch FFTPeriodSelector to ceiling-based period computation with a backward-compatible fallback
- add coverage for ceiling periods across even/odd sequence lengths
- verify TimesBlock round-trips through its 1D→2D→1D reshape path without loss

## Testing
- pytest tests/test_fft_period_selector.py tests/test_times_block.py

------
https://chatgpt.com/codex/tasks/task_e_68d1e82840b883289d8ea4d7e5e6540d