### PR TITLE
Fix FFT period selector DC bin removal before ranking

### DIFF
--- a/src/timesnet_forecast/models/timesnet.py
+++ b/src/timesnet_forecast/models/timesnet.py
@@ -74,7 +74,7 @@ class FFTPeriodSelector(nn.Module):
             return empty_idx, empty_amp.to(dtype)
 
         amp_mean = amp_mean.to(dtype)
-        amp_mean[0] = 0.0  # Remove DC component
+        amp_mean[0] = amp_mean.new_tensor(float("-inf"))  # Remove DC component
 
         available = amp_mean.numel() - 1
         k = min(self.k, available)


### PR DESCRIPTION
## Summary
- ensure the FFT period selector marks the DC bin as negative infinity before ranking
- keep existing safeguards while preventing the DC component from being selected

## Testing
- pytest tests/test_fft_period_selector.py

------
https://chatgpt.com/codex/tasks/task_e_68d1f723f0f083289df3e36a17bef484