### PR TITLE
Add deterministic training toggle and regression test

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,5 +22,6 @@
 - Using CUDA Graphs (`train.cuda_graphs: true`) disables dropout because the model is placed in evaluation mode during graph capture. This trades regularization for faster execution.
 - Activation checkpointing can be toggled via `train.use_checkpoint`. Enabling it reduces memory usage at the cost of slower training throughput and is automatically turned off when CUDA graphs are active.
 - Manual CUDA graph capture (`train.cuda_graphs`) and `torch.compile` (`train.compile`) are mutually exclusive. TorchDynamo already performs graph capture and its compiled modules cannot be re-captured safely.
+- Enable fully deterministic execution by setting `train.deterministic: true`. This seeds every RNG, disables cuDNN benchmarking, and enforces deterministic algorithms via `torch.use_deterministic_algorithms`, yielding reproducible metrics and weights for integration tests.
 - Sliding windows are fixed to `model.input_len` without zero padding. Ensure both training and inference provide at least that much history; optional temporal covariates can be passed alongside the values tensor when using the built-in embedding.
 - The model "telescopes" input sequences: `TimesNet.forward` always crops to the first `input_len` steps of the periodic canvas, so passing extra history at inference produces the same `[B, pred_len, N]` shaped output as training.

--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -32,6 +32,7 @@ train:
   grad_clip_norm: 1.0
   amp: true
   compile: false
+  deterministic: false
   cuda_graphs: false         # Mutually exclusive with compile
   use_checkpoint: false      # Enable activation checkpointing to save memory at the cost of speed
   min_sigma: 1.0e-3

--- a/src/timesnet_forecast/dependency.py
+++ b/src/timesnet_forecast/dependency.py
@@ -11,9 +11,9 @@ def bootstrap(cfg: dict) -> torch.device:
     if want == "cuda" and not torch.cuda.is_available():
         console().print("[yellow]CUDA not available; falling back to CPU.[/yellow]")
     device = torch.device("cuda:0" if (want == "cuda" and torch.cuda.is_available()) else "cpu")
-    torch.backends.cudnn.benchmark = True
+    deterministic = bool(cfg["train"].get("deterministic", False))
     torch.set_float32_matmul_precision(cfg["train"]["matmul_precision"])
-    seed_everything(int(cfg.get("tuning", {}).get("seed", 2025)))
+    seed_everything(int(cfg.get("tuning", {}).get("seed", 2025)), deterministic=deterministic)
     return device
 
 

--- a/src/timesnet_forecast/train.py
+++ b/src/timesnet_forecast/train.py
@@ -405,9 +405,9 @@ def _eval_metrics(
 def train_once(cfg: Dict) -> Tuple[float, Dict]:
     # --- bootstrap
     device = _select_device(cfg["train"]["device"])
-    torch.backends.cudnn.benchmark = True
+    deterministic = bool(cfg["train"].get("deterministic", False))
     torch.set_float32_matmul_precision(cfg["train"]["matmul_precision"])
-    seed_everything(int(cfg.get("tuning", {}).get("seed", 2025)))
+    seed_everything(int(cfg.get("tuning", {}).get("seed", 2025)), deterministic=deterministic)
     console().print(f"[bold green]Device:[/bold green] {device}")
 
     use_graphs = _should_use_cuda_graphs(cfg["train"], device)

--- a/src/timesnet_forecast/utils/seed.py
+++ b/src/timesnet_forecast/utils/seed.py
@@ -2,14 +2,24 @@ from __future__ import annotations
 
 import os
 import random
+
 import numpy as np
 import torch
 
 
-def seed_everything(seed: int) -> None:
+def seed_everything(seed: int, deterministic: bool = False) -> None:
     random.seed(seed)
     np.random.seed(seed)
     os.environ["PYTHONHASHSEED"] = str(seed)
     torch.manual_seed(seed)
     if torch.cuda.is_available():
         torch.cuda.manual_seed_all(seed)
+
+    if deterministic:
+        torch.backends.cudnn.deterministic = True
+        torch.backends.cudnn.benchmark = False
+        torch.use_deterministic_algorithms(True, warn_only=False)
+    else:
+        torch.backends.cudnn.deterministic = False
+        torch.backends.cudnn.benchmark = True
+        torch.use_deterministic_algorithms(False)

--- a/tests/test_deterministic_training.py
+++ b/tests/test_deterministic_training.py
@@ -1,0 +1,96 @@
+import math
+from pathlib import Path
+import sys
+from typing import Dict
+
+import torch
+
+# Ensure the project src is on the path for imports
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from timesnet_forecast.models.timesnet import TimesNet
+from timesnet_forecast.train import gaussian_nll_loss
+from timesnet_forecast.utils.seed import seed_everything
+
+
+def _run_short_training(seed: int) -> tuple[torch.Tensor, Dict[str, torch.Tensor]]:
+    seed_everything(seed, deterministic=True)
+
+    T = 48
+    input_len, pred_len = 12, 4
+    t = torch.arange(T, dtype=torch.float32)
+    data = torch.stack(
+        [
+            0.5 + torch.sin(2 * math.pi * t / 12.0),
+            -0.25 + torch.cos(2 * math.pi * t / 8.0),
+        ],
+        dim=-1,
+    )
+
+    train_series = data[:32]
+    X_windows, Y_windows = [], []
+    for start in range(0, train_series.size(0) - input_len - pred_len + 1):
+        window = train_series[start : start + input_len + pred_len]
+        X_windows.append(window[:input_len])
+        Y_windows.append(window[input_len:])
+    X = torch.stack(X_windows)
+    Y = torch.stack(Y_windows)
+
+    model = TimesNet(
+        input_len=input_len,
+        pred_len=pred_len,
+        d_model=16,
+        d_ff=32,
+        n_layers=2,
+        k_periods=2,
+        kernel_set=[(3, 3)],
+        dropout=0.0,
+        activation="gelu",
+        mode="direct",
+    )
+
+    optimizer = torch.optim.Adam(model.parameters(), lr=0.01)
+    history = []
+    batch_size = 8
+    for _ in range(3):
+        perm = torch.randperm(X.size(0))
+        total_loss = 0.0
+        count = 0
+        for j in range(0, len(perm), batch_size):
+            idx = perm[j : j + batch_size]
+            xb = X[idx]
+            yb = Y[idx]
+            optimizer.zero_grad()
+            mu, sigma = model(xb)
+            loss = gaussian_nll_loss(mu, sigma, yb).mean()
+            loss.backward()
+            optimizer.step()
+            total_loss += float(loss.detach())
+            count += 1
+        history.append(total_loss / max(count, 1))
+
+    state = {k: v.detach().clone() for k, v in model.state_dict().items()}
+    return torch.tensor(history, dtype=torch.float64), state
+
+
+def test_deterministic_training_reproducible():
+    prev_deterministic = torch.backends.cudnn.deterministic
+    prev_benchmark = torch.backends.cudnn.benchmark
+    prev_algorithms = torch.are_deterministic_algorithms_enabled()
+    prev_warn_only = torch.is_deterministic_algorithms_warn_only_enabled()
+
+    try:
+        losses_a, state_a = _run_short_training(2024)
+        losses_b, state_b = _run_short_training(2024)
+    finally:
+        if prev_algorithms:
+            torch.use_deterministic_algorithms(True, warn_only=prev_warn_only)
+        else:
+            torch.use_deterministic_algorithms(False)
+        torch.backends.cudnn.deterministic = prev_deterministic
+        torch.backends.cudnn.benchmark = prev_benchmark
+
+    torch.testing.assert_close(losses_a, losses_b)
+    assert state_a.keys() == state_b.keys()
+    for key in state_a:
+        torch.testing.assert_close(state_a[key], state_b[key])


### PR DESCRIPTION
## Summary
- allow seed utility to enforce deterministic CUDA/cuDNN behaviour when requested
- surface a `train.deterministic` configuration flag and document it in the README
- add a regression test that trains twice with the same seed and asserts identical losses and weights

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d2877898f4832896c12f4d073fada5