### PR TITLE
Add static feature computation and metadata

### DIFF
--- a/src/timesnet_forecast/utils/static_features.py
+++ b/src/timesnet_forecast/utils/static_features.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+_F32_EPS = np.float32(1e-6)
+
+
+def _safe_divide(numer: np.ndarray, denom: np.ndarray) -> np.ndarray:
+    """Element-wise division with float32 outputs and EPS-denominator clamp."""
+
+    denom_safe = np.maximum(denom.astype(np.float32, copy=False), _F32_EPS)
+    result = numer.astype(np.float32, copy=False) / denom_safe
+    return result.astype(np.float32, copy=False)
+
+
+def compute_series_features(
+    wide_df: pd.DataFrame, mask_df: pd.DataFrame
+) -> tuple[np.ndarray, list[str]]:
+    """Compute per-series static features for wide-form time series data.
+
+    Args:
+        wide_df: Wide-form dataframe shaped ``[T, N]`` with series in columns.
+        mask_df: DataFrame with the same shape as ``wide_df`` indicating valid
+            observations (``>0``) for each timestamp and series.
+
+    Returns:
+        Tuple ``(features, feature_names)`` where ``features`` is an array shaped
+        ``[N, F]`` containing ``float32`` features and ``feature_names`` lists the
+        column names in ``features``.
+    """
+
+    if wide_df.shape != mask_df.shape:
+        raise ValueError("wide_df and mask_df must have the same shape")
+
+    values = wide_df.to_numpy(dtype=np.float32, copy=False)
+    mask = mask_df.to_numpy(dtype=np.float32, copy=False)
+    time_steps, num_series = values.shape
+
+    feature_names = [
+        "mean",
+        "std",
+        "diff_std",
+        "seasonal_strength",
+        "dominant_period",
+    ]
+
+    if num_series == 0:
+        return np.zeros((0, len(feature_names)), dtype=np.float32), feature_names
+
+    counts = mask.sum(axis=0, dtype=np.float32)
+    sum_vals = (values * mask).sum(axis=0, dtype=np.float32)
+    mean = _safe_divide(sum_vals, counts)
+
+    centered = (values - mean[np.newaxis, :]) * mask
+    var = _safe_divide(
+        (centered * centered).sum(axis=0, dtype=np.float32),
+        np.maximum(counts, np.float32(1.0)),
+    )
+    std = np.sqrt(np.clip(var, 0.0, None)).astype(np.float32)
+
+    if time_steps > 1:
+        diffs = values[1:, :] - values[:-1, :]
+        diff_mask = mask[1:, :] * mask[:-1, :]
+        diff_counts = diff_mask.sum(axis=0, dtype=np.float32)
+        diff_sum = (diffs * diff_mask).sum(axis=0, dtype=np.float32)
+        diff_mean = _safe_divide(diff_sum, diff_counts)
+        diff_centered = (diffs - diff_mean[np.newaxis, :]) * diff_mask
+        diff_var = _safe_divide(
+            (diff_centered * diff_centered).sum(axis=0, dtype=np.float32),
+            np.maximum(diff_counts, np.float32(1.0)),
+        )
+        diff_std = np.sqrt(np.clip(diff_var, 0.0, None)).astype(np.float32)
+    else:
+        diff_std = np.zeros(num_series, dtype=np.float32)
+
+    if time_steps > 1:
+        demeaned = np.where(mask > 0.0, values - mean[np.newaxis, :], 0.0)
+        fft_vals = np.fft.rfft(demeaned, axis=0)
+        power = np.abs(fft_vals) ** 2
+        if power.shape[0] > 1:
+            power_no_dc = power[1:, :]
+            peak_indices = np.argmax(power_no_dc, axis=0)
+            cols = np.arange(num_series)
+            peak_power = power_no_dc[peak_indices, cols]
+            total_power = power_no_dc.sum(axis=0)
+            seasonal_strength = _safe_divide(peak_power, total_power)
+            dominant_period = np.where(
+                total_power > _F32_EPS,
+                (time_steps / np.maximum(peak_indices + 1, 1)).astype(np.float32),
+                0.0,
+            ).astype(np.float32)
+        else:
+            seasonal_strength = np.zeros(num_series, dtype=np.float32)
+            dominant_period = np.zeros(num_series, dtype=np.float32)
+    else:
+        seasonal_strength = np.zeros(num_series, dtype=np.float32)
+        dominant_period = np.zeros(num_series, dtype=np.float32)
+
+    features = np.stack(
+        [mean, std, diff_std, seasonal_strength, dominant_period], axis=1
+    ).astype(np.float32, copy=False)
+    return features, feature_names

--- a/tests/test_global_pmax.py
+++ b/tests/test_global_pmax.py
@@ -117,5 +117,20 @@ def test_train_once_runs_without_pmax(tmp_path):
     assert trn_norm.shape[0] >= cfg["model"]["input_len"]
 
     train.train_once(cfg)
+    scaler_meta = io_utils.load_pickle(
+        tmp_path / "artifacts" / cfg["artifacts"]["scaler_file"]
+    )
+    static_features = scaler_meta.get("static_features")
+    feature_names = scaler_meta.get("feature_names")
+    assert isinstance(static_features, np.ndarray)
+    assert static_features.dtype == np.float32
+    assert static_features.shape[0] == len(scaler_meta["ids"])
+    assert feature_names == [
+        "mean",
+        "std",
+        "diff_std",
+        "seasonal_strength",
+        "dominant_period",
+    ]
     assert "pmax" not in cfg.get("model", {})
 

--- a/tests/test_static_features.py
+++ b/tests/test_static_features.py
@@ -1,0 +1,62 @@
+from pathlib import Path
+import sys
+
+import numpy as np
+import pandas as pd
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from timesnet_forecast.utils.static_features import compute_series_features
+
+
+def test_compute_series_features_small_sample():
+    T = 12
+    t = np.arange(T, dtype=np.float32)
+    series_a = 5.0 + np.sin(2 * np.pi * t / 3.0)
+    series_b = np.full(T, 2.0, dtype=np.float32)
+    series_c = np.array(
+        [1.0, 2.0, np.nan, 4.0, 5.0, 6.0, np.nan, 8.0, 9.0, 10.0, np.nan, 12.0],
+        dtype=np.float32,
+    )
+
+    wide_raw = pd.DataFrame({"A": series_a, "B": series_b, "C": series_c})
+    mask_df = (~wide_raw.isna()).astype(np.float32)
+    wide = wide_raw.fillna(0.0)
+
+    features, names = compute_series_features(wide, mask_df)
+
+    assert names == [
+        "mean",
+        "std",
+        "diff_std",
+        "seasonal_strength",
+        "dominant_period",
+    ]
+    assert features.shape == (3, len(names))
+    assert features.dtype == np.float32
+
+    expected_mean_a = float(series_a.mean())
+    expected_std_a = float(series_a.std(ddof=0))
+    expected_diff_std_a = float(np.diff(series_a).std(ddof=0))
+
+    valid_c = wide_raw["C"].dropna().to_numpy(dtype=np.float32)
+    expected_mean_c = float(valid_c.mean())
+    expected_std_c = float(valid_c.std(ddof=0))
+
+    np.testing.assert_allclose(features[0, 0], expected_mean_a, rtol=1e-5, atol=1e-5)
+    np.testing.assert_allclose(features[0, 1], expected_std_a, rtol=1e-5, atol=1e-5)
+    np.testing.assert_allclose(
+        features[0, 2], expected_diff_std_a, rtol=1e-5, atol=1e-5
+    )
+    np.testing.assert_allclose(features[0, 4], 3.0, rtol=1e-5, atol=1e-5)
+    assert 0.9 <= float(features[0, 3]) <= 1.0
+
+    np.testing.assert_allclose(
+        features[1], np.array([2.0, 0.0, 0.0, 0.0, 0.0], dtype=np.float32)
+    )
+
+    np.testing.assert_allclose(features[2, 0], expected_mean_c, rtol=1e-5, atol=1e-5)
+    np.testing.assert_allclose(features[2, 1], expected_std_c, rtol=1e-5, atol=1e-5)
+    np.testing.assert_allclose(features[2, 2], 0.0, atol=1e-6)
+    assert 0.0 <= float(features[2, 3]) <= 1.0
+    assert float(features[2, 4]) >= 0.0


### PR DESCRIPTION
## Summary
- add a static feature utility that derives masked means, standard deviations, first-difference spread, and FFT-based indicators in float32
- compute the static features during training so numpy and tensor forms are available and persist them in the scaler metadata
- cover the new behaviour with unit tests, including verifying the scaler artifact exposes the feature names and values

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d2a0eff05c832887f31e13784d891c