### PR TITLE
Add configurable time feature support

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -12,6 +12,11 @@ data:
   augment:
     add_noise_std: 0.0       # 표준편차; 0이면 사용 안 함
     time_shift: 0            # 입력 시퀀스 시작 위치 랜덤 시프트 범위
+  time_features:
+    enabled: false
+    features: [day_of_week, day_of_month, month, day_of_year]
+    encoding: cyclical       # cyclical|onehot|numeric (or per-feature mapping)
+    normalize: true
 
 preprocess:
   to_wide: true

--- a/src/timesnet_forecast/predict.py
+++ b/src/timesnet_forecast/predict.py
@@ -298,6 +298,14 @@ def predict_once(cfg: Dict) -> str:
         if cfg_used["train"]["channels_last"]:
             dummy = dummy.unsqueeze(-1).to(memory_format=torch.channels_last).squeeze(-1)
         warmup_kwargs = {}
+        if time_features_enabled and meta_dim > 0:
+            warmup_kwargs["x_mark"] = torch.zeros(
+                1,
+                input_len,
+                meta_dim,
+                device=device,
+                dtype=torch.float32,
+            )
         if static_tensor_full is not None:
             warmup_kwargs["series_static"] = static_tensor_full
         if full_series_ids_tensor is not None:

--- a/src/timesnet_forecast/train.py
+++ b/src/timesnet_forecast/train.py
@@ -829,6 +829,15 @@ def train_once(cfg: Dict) -> Tuple[float, Dict]:
         "series_static": warmup_series_static,
         "series_ids": series_ids_default,
     }
+    warmup_kwargs = {k: v for k, v in warmup_kwargs.items() if v is not None}
+    if time_features_enabled and time_feature_dim > 0:
+        warmup_kwargs["x_mark"] = torch.zeros(
+            1,
+            input_len,
+            time_feature_dim,
+            device=device,
+            dtype=torch.float32,
+        )
     with torch.no_grad():
         dummy = torch.zeros(1, input_len, len(ids), device=device)
         model(dummy, **warmup_kwargs)

--- a/src/timesnet_forecast/train.py
+++ b/src/timesnet_forecast/train.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 import time
 import math
-from typing import Dict, List, Tuple, Optional
+from typing import Dict, List, Tuple, Optional, Iterable
 import numpy as np
 import pandas as pd
 import torch
@@ -107,6 +107,9 @@ def _build_dataloader(
     augment: Dict | None = None,
     series_static: List[np.ndarray | None] | None = None,
     series_ids: List[np.ndarray | None] | None = None,
+    time_indices: List[pd.DatetimeIndex | np.ndarray | None] | None = None,
+    time_features: List[np.ndarray | None] | None = None,
+    time_feature_config: Dict | None = None,
 ) -> DataLoader:
     if len(arrays) != len(masks):
         raise ValueError("arrays and masks must have the same length")
@@ -114,6 +117,10 @@ def _build_dataloader(
         raise ValueError("series_static must match arrays length when provided")
     if series_ids is not None and len(series_ids) != len(arrays):
         raise ValueError("series_ids must match arrays length when provided")
+    if time_indices is not None and len(time_indices) != len(arrays):
+        raise ValueError("time_indices must match arrays length when provided")
+    if time_features is not None and len(time_features) != len(arrays):
+        raise ValueError("time_features must match arrays length when provided")
     datasets = [
         SlidingWindowDataset(
             a,
@@ -125,6 +132,9 @@ def _build_dataloader(
             valid_mask=m,
             series_static=series_static[i] if series_static is not None else None,
             series_ids=series_ids[i] if series_ids is not None else None,
+            time_index=time_indices[i] if time_indices is not None else None,
+            time_features=time_features[i] if time_features is not None else None,
+            time_feature_config=time_feature_config,
         )
         for i, (a, m) in enumerate(zip(arrays, masks))
     ]
@@ -144,35 +154,106 @@ def _build_dataloader(
     )
 
 
-def _unpack_batch(batch) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor | None, torch.Tensor | None]:
+def _iter_datasets(dataset) -> Iterable[SlidingWindowDataset]:
+    if isinstance(dataset, ConcatDataset):
+        for sub in dataset.datasets:
+            yield from _iter_datasets(sub)
+    elif isinstance(dataset, SlidingWindowDataset):
+        yield dataset
+
+
+def _time_feature_dim_from_dataset(dataset) -> int:
+    for ds in _iter_datasets(dataset):
+        dim = getattr(ds, "time_feature_dim", 0)
+        if dim:
+            return int(dim)
+    return 0
+
+
+def _time_frequency_from_dataset(dataset) -> str | None:
+    for ds in _iter_datasets(dataset):
+        freq = getattr(ds, "time_frequency", None)
+        if freq:
+            return str(freq)
+    return None
+
+
+def _normalize_optional(value):
+    if value is None:
+        return None
+    if isinstance(value, (list, tuple)):
+        if not value:
+            return None
+        if all(v is None for v in value):
+            return None
+    if isinstance(value, torch.Tensor) and value.numel() == 0:
+        return None
+    return value
+
+
+def _unpack_batch(
+    batch,
+) -> tuple[
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor | None,
+    torch.Tensor | None,
+    torch.Tensor | None,
+    torch.Tensor | None,
+]:
     if not isinstance(batch, (list, tuple)):
         raise TypeError("batch must be a tuple or list of tensors")
-    if len(batch) == 3:
-        xb, yb, mask = batch
-        static = None
-        series_ids = None
-    elif len(batch) == 4:
-        xb, yb, mask, static = batch
-        series_ids = None
-    elif len(batch) == 5:
-        xb, yb, mask, static, series_ids = batch
-    else:
+    if len(batch) < 3:
         raise ValueError(f"Unexpected batch size: {len(batch)}")
-    return xb, yb, mask, static, series_ids
+    xb, yb, mask = batch[0], batch[1], batch[2]
+    next_idx = 3
+    x_mark: torch.Tensor | None = None
+    y_mark: torch.Tensor | None = None
+    if len(batch) >= 5:
+        x_mark = _normalize_optional(batch[3])
+        y_mark = _normalize_optional(batch[4])
+        next_idx = 5
+    static: torch.Tensor | None = None
+    series_ids: torch.Tensor | None = None
+    if len(batch) > next_idx:
+        static = batch[next_idx]
+        next_idx += 1
+    if len(batch) > next_idx:
+        series_ids = batch[next_idx]
+        next_idx += 1
+    if len(batch) != next_idx:
+        raise ValueError(f"Unexpected batch size: {len(batch)}")
+    return xb, yb, mask, x_mark, y_mark, static, series_ids
 
 
 def _call_model_optional(
     model: nn.Module,
     xb: torch.Tensor,
+    x_mark: torch.Tensor | None,
     series_static: torch.Tensor | None,
     series_ids: torch.Tensor | None,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
+    kwargs: Dict[str, torch.Tensor] = {}
+    if x_mark is not None:
+        kwargs["x_mark"] = x_mark
+    if series_static is not None:
+        kwargs["series_static"] = series_static
+    if series_ids is not None:
+        kwargs["series_ids"] = series_ids
     try:
-        return model(xb, series_static=series_static, series_ids=series_ids)
+        return model(xb, **kwargs)
     except TypeError as err:
         err_str = str(err)
-        if "series_static" in err_str or "series_ids" in err_str:
-            return model(xb)
+        fallback_keys = ["series_static", "series_ids", "x_mark"]
+        for key in fallback_keys:
+            if key in kwargs and key in err_str:
+                kwargs.pop(key)
+                try:
+                    return model(xb, **kwargs)
+                except TypeError as err_inner:
+                    err_str = str(err_inner)
+                    continue
         raise
 
 
@@ -365,11 +446,15 @@ def _eval_wsmape(
     default_series_ids = torch.arange(len(ids), dtype=torch.long, device=device)
     with torch.inference_mode(), amp_autocast(True if device.type == "cuda" else False):
         for batch in loader:
-            xb, yb, mask, static, series_idx = _unpack_batch(batch)
+            xb, yb, mask, x_mark, y_mark, static, series_idx = _unpack_batch(batch)
             xb = move_to_device(xb, device)  # [B, L, N]
             yb = move_to_device(yb, device)  # [B, H_or_1, N]
             mask_dev = move_to_device(mask, device)
             loss_mask = mask_dev.to(yb.dtype) if use_loss_mask else None
+            if x_mark is not None:
+                x_mark = x_mark.to(device=device, non_blocking=True)
+            if y_mark is not None:
+                y_mark = y_mark.to(device=device, non_blocking=True)
             if static is not None:
                 static = move_to_device(static, device)
             if series_idx is not None:
@@ -381,7 +466,7 @@ def _eval_wsmape(
             _assert_min_len(xb, _model_input_len(model))
             if mode == "direct":
                 mu, _ = _call_model_optional(
-                    model, xb, static, series_idx
+                    model, xb, x_mark, static, series_idx
                 )
             else:
                 # recursive multi-step forecast during validation
@@ -389,6 +474,8 @@ def _eval_wsmape(
                     model,
                     xb,
                     pred_len,
+                    x_mark=x_mark,
+                    y_mark=y_mark,
                     series_static=static,
                     series_ids=series_idx,
                 )
@@ -425,11 +512,15 @@ def _eval_metrics(
     default_series_ids = torch.arange(len(ids), dtype=torch.long, device=device)
     with torch.inference_mode(), amp_autocast(True if device.type == "cuda" else False):
         for batch in loader:
-            xb, yb, mask, static, series_idx = _unpack_batch(batch)
+            xb, yb, mask, x_mark, y_mark, static, series_idx = _unpack_batch(batch)
             xb = move_to_device(xb, device)  # [B, L, N]
             yb = move_to_device(yb, device)  # [B, H_or_1, N]
             mask_dev = move_to_device(mask, device)
             loss_mask = mask_dev.to(yb.dtype) if use_loss_mask else None
+            if x_mark is not None:
+                x_mark = x_mark.to(device=device, non_blocking=True)
+            if y_mark is not None:
+                y_mark = y_mark.to(device=device, non_blocking=True)
             if static is not None:
                 static = move_to_device(static, device)
             if series_idx is not None:
@@ -443,6 +534,7 @@ def _eval_metrics(
                 mu, sigma = _call_model_optional(
                     model,
                     xb,
+                    x_mark,
                     static,
                     series_idx,
                 )
@@ -451,6 +543,8 @@ def _eval_metrics(
                     model,
                     xb,
                     pred_len,
+                    x_mark=x_mark,
+                    y_mark=y_mark,
                     series_static=static,
                     series_ids=series_idx,
                 )
@@ -496,6 +590,12 @@ def train_once(cfg: Dict) -> Tuple[float, Dict]:
 
     # --- data loading
     schema = io_utils.resolve_schema(cfg)
+    data_cfg = cfg.setdefault("data", {})
+    time_feature_cfg_raw = data_cfg.get("time_features") or {}
+    time_feature_cfg = dict(time_feature_cfg_raw)
+    time_feature_cfg.setdefault("enabled", False)
+    time_features_enabled = bool(time_feature_cfg.get("enabled", False))
+    data_cfg["time_features"] = time_feature_cfg
     enc = cfg["data"]["encoding"]
     train_path = cfg["data"]["train_csv"]
     df = pd.read_csv(train_path, encoding=enc)
@@ -516,6 +616,8 @@ def train_once(cfg: Dict) -> Tuple[float, Dict]:
     norm_per_series = cfg["preprocess"]["normalize_per_series"]
     eps = cfg["preprocess"]["eps"]
 
+    train_time_indices: List[pd.DatetimeIndex | None] | None = None
+    val_time_indices: List[pd.DatetimeIndex | None] | None = None
     if cfg["train"]["val"]["strategy"] == "holdout":
         trn_df, val_df = make_holdout_slices(wide, cfg["train"]["val"]["holdout_days"])
         trn_mask_df, val_mask_df = make_holdout_slices(mask_wide, cfg["train"]["val"]["holdout_days"])
@@ -532,6 +634,12 @@ def train_once(cfg: Dict) -> Tuple[float, Dict]:
         val_arrays = [val_norm.to_numpy(dtype=np.float32, copy=False)]
         train_mask_arrays = [trn_mask_df.to_numpy(dtype=np.float32, copy=False)]
         val_mask_arrays = [val_mask_df.to_numpy(dtype=np.float32, copy=False)]
+        if time_features_enabled:
+            train_time_indices = [pd.DatetimeIndex(trn_norm.index)]
+            val_time_indices = [pd.DatetimeIndex(val_norm.index)]
+        else:
+            train_time_indices = None
+            val_time_indices = None
     else:
         val_cfg = cfg["train"]["val"]
         fold_iter = make_rolling_slices(
@@ -555,6 +663,12 @@ def train_once(cfg: Dict) -> Tuple[float, Dict]:
         val_arrays: List[np.ndarray] = []
         train_mask_arrays: List[np.ndarray] = []
         val_mask_arrays: List[np.ndarray] = []
+        if time_features_enabled:
+            train_time_indices = []
+            val_time_indices = []
+        else:
+            train_time_indices = None
+            val_time_indices = None
         for (tr_df, va_df), (tr_mask_df, va_mask_df) in zip(
             make_rolling_slices(
                 wide_norm, val_cfg["rolling_folds"], val_cfg["rolling_step_days"], val_cfg["holdout_days"]
@@ -567,6 +681,10 @@ def train_once(cfg: Dict) -> Tuple[float, Dict]:
             val_arrays.append(va_df.to_numpy(dtype=np.float32, copy=False))
             train_mask_arrays.append(tr_mask_df.to_numpy(dtype=np.float32, copy=False))
             val_mask_arrays.append(va_mask_df.to_numpy(dtype=np.float32, copy=False))
+            if time_features_enabled:
+                assert train_time_indices is not None and val_time_indices is not None
+                train_time_indices.append(pd.DatetimeIndex(tr_df.index))
+                val_time_indices.append(pd.DatetimeIndex(va_df.index))
 
     # --- model hyper-parameters derived from config
     cfg.setdefault("model", {})
@@ -589,6 +707,8 @@ def train_once(cfg: Dict) -> Tuple[float, Dict]:
         augment=cfg["data"].get("augment"),
         series_static=train_static_list,
         series_ids=train_id_list,
+        time_indices=train_time_indices,
+        time_feature_config=time_feature_cfg if time_features_enabled else None,
     )
     dl_val = _build_dataloader(
         val_arrays, val_mask_arrays, input_len, pred_len, mode, batch_size=cfg["train"]["batch_size"],
@@ -599,9 +719,28 @@ def train_once(cfg: Dict) -> Tuple[float, Dict]:
         augment=None,
         series_static=val_static_list,
         series_ids=val_id_list,
+        time_indices=val_time_indices,
+        time_feature_config=time_feature_cfg if time_features_enabled else None,
     )
     if len(dl_val.dataset) == 0:
         raise ValueError("Validation split has no windows; increase train.val.holdout_days or adjust model.input_len/pred_len.")
+    time_feature_dim = _time_feature_dim_from_dataset(dl_train.dataset)
+    dataset_freq = _time_frequency_from_dataset(dl_train.dataset)
+    base_index = wide.index if isinstance(wide.index, pd.DatetimeIndex) else None
+    inferred_freq = dataset_freq
+    if inferred_freq is None and base_index is not None:
+        inferred_freq = getattr(base_index, "freqstr", None)
+        if inferred_freq is None:
+            inferred_freq = pd.infer_freq(base_index)
+    cfg["data"]["time_features"]["feature_dim"] = int(time_feature_dim)
+    if inferred_freq is not None:
+        cfg["data"]["time_features"]["freq"] = inferred_freq
+    time_feature_meta = {
+        "enabled": bool(time_features_enabled and time_feature_dim > 0),
+        "feature_dim": int(time_feature_dim),
+        "config": dict(time_feature_cfg),
+        "freq": inferred_freq,
+    }
     warmup_series_static = torch.from_numpy(series_static_np).to(
         device=device, dtype=torch.float32
     )
@@ -853,12 +992,13 @@ def train_once(cfg: Dict) -> Tuple[float, Dict]:
         graph_captured = False
         static_series_buf: torch.Tensor | None = None
         static_ids_buf: torch.Tensor | None = None
+        static_mark_buf: torch.Tensor | None = None
         for w in range(warmup_iters):
             try:
                 batch_w = next(train_iter)
             except StopIteration:
                 break
-            xb_w, yb_w, mask_w, static_w, series_ids_w = _unpack_batch(batch_w)
+            xb_w, yb_w, mask_w, x_mark_w, y_mark_w, static_w, series_ids_w = _unpack_batch(batch_w)
             xb_w = xb_w.to(device, non_blocking=True)
             yb_w = yb_w.to(device, non_blocking=True)
             if use_loss_masking:
@@ -866,6 +1006,10 @@ def train_once(cfg: Dict) -> Tuple[float, Dict]:
                 mb_w = mask_w.to(yb_w.dtype)
             else:
                 mb_w = torch.ones_like(yb_w, dtype=yb_w.dtype, device=device)
+            if x_mark_w is not None:
+                x_mark_w = x_mark_w.to(device=device, non_blocking=True)
+            if y_mark_w is not None:
+                y_mark_w = y_mark_w.to(device=device, non_blocking=True)
             if static_w is not None:
                 static_w = static_w.to(device=device, non_blocking=True)
             if series_ids_w is not None:
@@ -880,6 +1024,7 @@ def train_once(cfg: Dict) -> Tuple[float, Dict]:
             with amp_autocast(cfg["train"]["amp"] and device.type == "cuda"):
                 mu_w, sigma_w = model(
                     xb_w,
+                    x_mark=x_mark_w,
                     series_static=static_w,
                     series_ids=series_ids_w,
                 )
@@ -901,7 +1046,7 @@ def train_once(cfg: Dict) -> Tuple[float, Dict]:
         except StopIteration:
             train_iter = iter(dl_train)
             batch0 = next(train_iter)
-        xb0, yb0, mask0, static0, series_ids0 = _unpack_batch(batch0)
+        xb0, yb0, mask0, x_mark0, y_mark0, static0, series_ids0 = _unpack_batch(batch0)
         xb0 = xb0.to(device, non_blocking=True)
         yb0 = yb0.to(device, non_blocking=True)
         if use_loss_masking:
@@ -909,6 +1054,10 @@ def train_once(cfg: Dict) -> Tuple[float, Dict]:
             mb0 = mask0.to(yb0.dtype)
         else:
             mb0 = torch.ones_like(yb0, dtype=yb0.dtype, device=device)
+        if x_mark0 is not None:
+            x_mark0 = x_mark0.to(device=device, non_blocking=True)
+        if y_mark0 is not None:
+            y_mark0 = y_mark0.to(device=device, non_blocking=True)
         if static0 is not None:
             static0 = static0.to(device=device, non_blocking=True)
         if series_ids0 is not None:
@@ -925,6 +1074,11 @@ def train_once(cfg: Dict) -> Tuple[float, Dict]:
         static_x.copy_(xb0)
         static_y.copy_(yb0)
         static_m.copy_(mb0)
+        if x_mark0 is not None:
+            static_mark_buf = torch.empty_like(x_mark0)
+            static_mark_buf.copy_(x_mark0)
+        else:
+            static_mark_buf = None
         if static0 is not None:
             static_series_buf = torch.empty_like(static0)
             static_series_buf.copy_(static0)
@@ -941,6 +1095,7 @@ def train_once(cfg: Dict) -> Tuple[float, Dict]:
                 _assert_min_len(static_x, _model_input_len(model))
                 static_mu, static_sigma = model(
                     static_x,
+                    x_mark=static_mark_buf,
                     series_static=static_series_buf,
                     series_ids=static_ids_buf,
                 )
@@ -962,12 +1117,23 @@ def train_once(cfg: Dict) -> Tuple[float, Dict]:
             xb: torch.Tensor,
             yb: torch.Tensor,
             mb: torch.Tensor,
+            x_mark: torch.Tensor | None,
             static_feat: torch.Tensor | None,
             series_idx: torch.Tensor,
         ) -> float:
             static_x.copy_(xb)
             static_y.copy_(yb)
             static_m.copy_(mb)
+            if static_mark_buf is not None:
+                if x_mark is None:
+                    raise RuntimeError(
+                        "x_mark must be provided during CUDA graph replay when time features are enabled"
+                    )
+                static_mark_buf.copy_(x_mark)
+            elif x_mark is not None:
+                raise RuntimeError(
+                    "x_mark provided but CUDA graph captured without temporal buffer"
+                )
             if static_series_buf is not None:
                 if static_feat is None:
                     raise RuntimeError(
@@ -993,7 +1159,7 @@ def train_once(cfg: Dict) -> Tuple[float, Dict]:
         iter_time_total = 0.0
         for i, batch in enumerate(tqdm(dl_train, desc=f"Epoch {ep}/{epochs}", leave=False)):
             iter_start = time.perf_counter()
-            xb, yb, mask, static_feat, series_idx = _unpack_batch(batch)
+            xb, yb, mask, x_mark, y_mark, static_feat, series_idx = _unpack_batch(batch)
             xb = xb.to(device, non_blocking=True)
             yb = yb.to(device, non_blocking=True)
             if use_loss_masking:
@@ -1001,6 +1167,10 @@ def train_once(cfg: Dict) -> Tuple[float, Dict]:
                 mb = mask.to(yb.dtype)
             else:
                 mb = torch.ones_like(yb, dtype=yb.dtype, device=device)
+            if x_mark is not None:
+                x_mark = x_mark.to(device=device, non_blocking=True)
+            if y_mark is not None:
+                y_mark = y_mark.to(device=device, non_blocking=True)
             if static_feat is not None:
                 static_feat = static_feat.to(device=device, non_blocking=True)
             if series_idx is not None:
@@ -1014,11 +1184,12 @@ def train_once(cfg: Dict) -> Tuple[float, Dict]:
             _assert_min_len(xb, _model_input_len(model))
             after_copy = time.perf_counter()
             if use_graphs:
-                loss_val = graph_step(xb, yb, mb, static_feat, series_idx)
+                loss_val = graph_step(xb, yb, mb, x_mark, static_feat, series_idx)
             else:
                 with amp_autocast(cfg["train"]["amp"] and device.type == "cuda"):
                     mu, sigma = model(
                         xb,
+                        x_mark=x_mark,
                         series_static=static_feat,
                         series_ids=series_idx,
                     )
@@ -1111,6 +1282,7 @@ def train_once(cfg: Dict) -> Tuple[float, Dict]:
             "ids": ids,
             "static_features": series_static_np,
             "feature_names": static_feature_names,
+            "time_features": time_feature_meta,
         },
         scaler_path,
     )

--- a/src/timesnet_forecast/utils/time_features.py
+++ b/src/timesnet_forecast/utils/time_features.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+from typing import Dict, Iterable, List, Mapping, Sequence, Tuple, Union
+
+import numpy as np
+import pandas as pd
+
+EncodingType = Union[str, Mapping[str, str]]
+
+DEFAULT_FEATURES: List[str] = [
+    "day_of_week",
+    "day_of_month",
+    "month",
+    "day_of_year",
+]
+
+
+def _extract_day_of_week(index: pd.DatetimeIndex) -> Tuple[np.ndarray, int]:
+    values = index.dayofweek.to_numpy()
+    return values.astype(np.int64, copy=False), 7
+
+
+def _extract_day_of_month(index: pd.DatetimeIndex) -> Tuple[np.ndarray, int]:
+    values = index.day.to_numpy() - 1
+    return values.astype(np.int64, copy=False), 31
+
+
+def _extract_month(index: pd.DatetimeIndex) -> Tuple[np.ndarray, int]:
+    values = index.month.to_numpy() - 1
+    return values.astype(np.int64, copy=False), 12
+
+
+def _extract_hour(index: pd.DatetimeIndex) -> Tuple[np.ndarray, int]:
+    values = index.hour.to_numpy()
+    return values.astype(np.int64, copy=False), 24
+
+
+def _extract_minute(index: pd.DatetimeIndex) -> Tuple[np.ndarray, int]:
+    values = index.minute.to_numpy()
+    return values.astype(np.int64, copy=False), 60
+
+
+def _extract_day_of_year(index: pd.DatetimeIndex) -> Tuple[np.ndarray, int]:
+    values = index.dayofyear.to_numpy() - 1
+    return values.astype(np.int64, copy=False), 366
+
+
+def _extract_week_of_year(index: pd.DatetimeIndex) -> Tuple[np.ndarray, int]:
+    iso = index.isocalendar()
+    week = getattr(iso, "week", None)
+    if week is None:
+        week = iso["week"]
+    values = week.to_numpy() - 1
+    return values.astype(np.int64, copy=False), 53
+
+
+FEATURE_EXTRACTORS = {
+    "day_of_week": _extract_day_of_week,
+    "day_of_month": _extract_day_of_month,
+    "month": _extract_month,
+    "hour": _extract_hour,
+    "minute": _extract_minute,
+    "day_of_year": _extract_day_of_year,
+    "week_of_year": _extract_week_of_year,
+}
+
+
+def _resolve_encoding(feature: str, encoding: EncodingType) -> str:
+    if isinstance(encoding, Mapping):
+        enc_val = encoding.get(feature, encoding.get("default", "cyclical"))
+    else:
+        enc_val = encoding
+    enc_str = str(enc_val).lower()
+    if enc_str not in {"cyclical", "onehot", "numeric"}:
+        raise ValueError(
+            f"Unsupported encoding '{enc_val}' for feature '{feature}'. Expected 'cyclical', 'onehot', or 'numeric'."
+        )
+    return enc_str
+
+
+def _encode_component(
+    values: np.ndarray, period: int, encoding: str, normalize: bool
+) -> np.ndarray:
+    if values.ndim != 1:
+        values = values.reshape(-1)
+    if period <= 0:
+        period = int(values.max(initial=0) - values.min(initial=0) + 1)
+        period = max(period, 1)
+    mod_values = np.mod(values, period)
+    if encoding == "cyclical":
+        if period == 0:
+            period = 1
+        angles = 2.0 * np.pi * (mod_values.astype(np.float32) / float(period))
+        sin_term = np.sin(angles)
+        cos_term = np.cos(angles)
+        return np.stack([sin_term, cos_term], axis=1).astype(np.float32, copy=False)
+    if encoding == "onehot":
+        onehot = np.zeros((values.size, int(period)), dtype=np.float32)
+        idx = mod_values.astype(np.int64, copy=False)
+        if idx.size > 0:
+            onehot[np.arange(idx.size), idx] = 1.0
+        return onehot
+    numeric = mod_values.astype(np.float32, copy=False)
+    if normalize and period > 1:
+        denom = float(period - 1)
+        if denom <= 0:
+            denom = 1.0
+        numeric = numeric / denom
+    return numeric.reshape(-1, 1)
+
+
+def _as_datetime_index(index: Union[pd.DatetimeIndex, Sequence]) -> pd.DatetimeIndex:
+    if isinstance(index, pd.DatetimeIndex):
+        return index
+    return pd.to_datetime(np.asarray(index))
+
+
+def build_time_features(
+    index: Union[pd.DatetimeIndex, Sequence],
+    config: Mapping[str, object] | None,
+    *,
+    return_names: bool = False,
+) -> Union[np.ndarray, Tuple[np.ndarray, List[str]]]:
+    """Construct a feature matrix of temporal covariates.
+
+    Args:
+        index: Datetime index describing each timestamp.
+        config: Dictionary containing keys ``enabled``, ``features``,
+            ``encoding``, and ``normalize``. Unknown keys are ignored.
+        return_names: When ``True`` the feature names are returned alongside the
+            matrix for debugging or logging purposes.
+
+    Returns:
+        ``np.ndarray`` with shape ``[len(index), feature_dim]`` in ``float32``
+        precision. When ``return_names`` is ``True`` a tuple containing the
+        matrix and a list of column names is returned.
+    """
+
+    cfg = dict(config or {})
+    enabled = bool(cfg.get("enabled", False))
+    idx = _as_datetime_index(index)
+    if not enabled:
+        empty = np.zeros((len(idx), 0), dtype=np.float32)
+        if return_names:
+            return empty, []
+        return empty
+
+    features: Iterable[str] = cfg.get("features") or DEFAULT_FEATURES
+    encoding_cfg: EncodingType = cfg.get("encoding", "cyclical")
+    normalize = bool(cfg.get("normalize", True))
+
+    matrices: List[np.ndarray] = []
+    names: List[str] = []
+    for feature in features:
+        extractor = FEATURE_EXTRACTORS.get(feature)
+        if extractor is None:
+            raise ValueError(f"Unsupported time feature '{feature}'.")
+        values, period = extractor(idx)
+        encoding = _resolve_encoding(feature, encoding_cfg)
+        encoded = _encode_component(values, period, encoding, normalize)
+        if encoded.size == 0:
+            continue
+        matrices.append(encoded.astype(np.float32, copy=False))
+        if encoding == "cyclical":
+            names.extend([f"{feature}_sin", f"{feature}_cos"])
+        elif encoding == "onehot":
+            names.extend([f"{feature}_{i}" for i in range(encoded.shape[1])])
+        else:
+            names.append(feature)
+
+    if not matrices:
+        empty = np.zeros((len(idx), 0), dtype=np.float32)
+        if return_names:
+            return empty, []
+        return empty
+
+    matrix = np.hstack(matrices).astype(np.float32, copy=False)
+    if return_names:
+        return matrix, names
+    return matrix
+
+
+__all__ = ["build_time_features"]

--- a/tests/test_dataset_pmax.py
+++ b/tests/test_dataset_pmax.py
@@ -2,12 +2,14 @@ import sys
 from pathlib import Path
 
 import numpy as np
+import pandas as pd
 import torch
 
 # Ensure the project src is on the path for imports
 sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
 
 from timesnet_forecast.data.dataset import SlidingWindowDataset
+from timesnet_forecast.utils.time_features import build_time_features
 
 
 def test_sliding_window_returns_raw_input_len():
@@ -22,12 +24,14 @@ def test_sliding_window_returns_raw_input_len():
     )
 
     assert len(ds) == len(values) - 3 - 2 + 1
-    x0, y0, m0 = ds[0]
+    x0, y0, m0, x_mark, y_mark = ds[0][:5]
     assert x0.shape == (3, 1)
     assert y0.shape == (2, 1)
     assert m0.shape == (2, 1)
     np.testing.assert_allclose(x0.squeeze(-1).numpy(), np.array([1.0, 2.0, 3.0], dtype=np.float32))
     np.testing.assert_allclose(y0.squeeze(-1).numpy(), np.array([4.0, 5.0], dtype=np.float32))
+    assert isinstance(x_mark, torch.Tensor) and x_mark.numel() == 0
+    assert isinstance(y_mark, torch.Tensor) and y_mark.numel() == 0
 
 
 def test_sliding_window_last_chunk_matches_source():
@@ -43,10 +47,12 @@ def test_sliding_window_last_chunk_matches_source():
         valid_mask=mask,
     )
 
-    x_last, y_last, m_last = ds[len(ds) - 1]
+    x_last, y_last, m_last, x_mark, y_mark = ds[len(ds) - 1][:5]
     np.testing.assert_allclose(x_last.squeeze(-1).numpy(), np.array([3.0, 4.0, 5.0, 6.0], dtype=np.float32))
     np.testing.assert_allclose(y_last.squeeze(-1).numpy(), np.array([7.0, 8.0, 9.0], dtype=np.float32))
     np.testing.assert_allclose(m_last.squeeze(-1).numpy(), np.array([1.0, 1.0, 1.0], dtype=np.float32))
+    assert isinstance(x_mark, torch.Tensor) and x_mark.numel() == 0
+    assert isinstance(y_mark, torch.Tensor) and y_mark.numel() == 0
 
 
 def test_sliding_window_static_features_collate_shape():
@@ -66,7 +72,7 @@ def test_sliding_window_static_features_collate_shape():
         series_ids=series_ids,
     )
 
-    x0, y0, m0, s0, ids0 = ds[0]
+    x0, y0, m0, x_mark, y_mark, s0, ids0 = ds[0]
     assert x0.dtype == torch.float32
     assert y0.dtype == torch.float32
     assert m0.dtype == torch.float32
@@ -74,8 +80,50 @@ def test_sliding_window_static_features_collate_shape():
     assert ids0.dtype == torch.long
     assert s0.shape == static.shape
     assert ids0.shape == series_ids.shape
+    assert isinstance(x_mark, torch.Tensor) and x_mark.numel() == 0
+    assert isinstance(y_mark, torch.Tensor) and y_mark.numel() == 0
 
     loader = torch.utils.data.DataLoader(ds, batch_size=2, shuffle=False)
-    xb, yb, mb, sb, idb = next(iter(loader))
+    xb, yb, mb, xmb, ymb, sb, idb = next(iter(loader))
     assert sb.shape == (2, static.shape[0], static.shape[1])
     assert idb.shape == (2, series_ids.shape[0])
+    assert isinstance(xmb, torch.Tensor) and xmb.numel() == 0
+    assert isinstance(ymb, torch.Tensor) and ymb.numel() == 0
+
+
+def test_sliding_window_time_features_marks():
+    idx = pd.date_range("2023-01-01", periods=8, freq="D")
+    values = np.arange(8, dtype=np.float32).reshape(-1, 1)
+    cfg = {"enabled": True, "features": ["day_of_week"], "encoding": "numeric", "normalize": False}
+    ds = SlidingWindowDataset(
+        values,
+        input_len=3,
+        pred_len=2,
+        mode="direct",
+        time_index=idx,
+        time_feature_config=cfg,
+    )
+    x0, y0, m0, x_mark, y_mark = ds[0][:5]
+    assert isinstance(x_mark, torch.Tensor)
+    assert isinstance(y_mark, torch.Tensor)
+    features = build_time_features(idx, cfg)
+    np.testing.assert_allclose(x_mark.numpy(), features[:3].reshape(3, -1))
+    np.testing.assert_allclose(y_mark.numpy(), features[3:5].reshape(2, -1))
+
+
+def test_sliding_window_time_features_collate_shapes():
+    idx = pd.date_range("2023-02-01", periods=10, freq="D")
+    values = np.linspace(0.0, 1.0, num=10, dtype=np.float32).reshape(-1, 1)
+    cfg = {"enabled": True, "features": ["day_of_month"], "encoding": "numeric", "normalize": True}
+    ds = SlidingWindowDataset(
+        values,
+        input_len=4,
+        pred_len=2,
+        mode="direct",
+        time_index=idx,
+        time_feature_config=cfg,
+    )
+    loader = torch.utils.data.DataLoader(ds, batch_size=2, shuffle=False)
+    xb, yb, mb, xmb, ymb = next(iter(loader))[:5]
+    assert xmb.shape == (2, 4, 1)
+    assert ymb.shape == (2, 2, 1)


### PR DESCRIPTION
## Summary
- add optional time-mark tensors to `SlidingWindowDataset` along with reusable builders for temporal covariates
- thread time feature configuration through training and prediction to precompute marks, persist metadata, and feed marks into TimesNet
- expose time feature settings in the default config and extend dataset tests to cover mark handling

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d36fac277883288dae03c9b51fc155