### PR TITLE
Configure cuBLAS workspace for deterministic training

### DIFF
--- a/src/timesnet_forecast/utils/seed.py
+++ b/src/timesnet_forecast/utils/seed.py
@@ -18,6 +18,19 @@ def seed_everything(seed: int, deterministic: bool = False) -> None:
     if deterministic:
         torch.backends.cudnn.deterministic = True
         torch.backends.cudnn.benchmark = False
+        if torch.cuda.is_available():
+            # ``torch.use_deterministic_algorithms`` enforces that all kernels
+            # selected by autograd are deterministic. GEMM operations backed by
+            # cuBLAS require a workspace configuration hint to guarantee
+            # determinism when CUDA >= 10.2 is used. Without setting the
+            # ``CUBLAS_WORKSPACE_CONFIG`` environment variable PyTorch raises a
+            # runtime error the first time such an operation is encountered
+            # (e.g. the temporal embedding ``nn.Linear`` used when time feature
+            # embeddings are enabled). Set a safe default if the user has not
+            # configured it explicitly so deterministic training just works.
+            workspace_env = os.environ.get("CUBLAS_WORKSPACE_CONFIG")
+            if workspace_env not in {":16:8", ":4096:8"}:
+                os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"
         torch.use_deterministic_algorithms(True, warn_only=False)
     else:
         torch.backends.cudnn.deterministic = False


### PR DESCRIPTION
## Summary
- automatically populate CUBLAS_WORKSPACE_CONFIG when deterministic mode is enabled so cuBLAS GEMM kernels stay reproducible
- document the connection between deterministic training and time feature embeddings in the seeding utility

## Testing
- pytest tests/test_deterministic_training.py

------
https://chatgpt.com/codex/tasks/task_e_68d37c86482483288e0f0721ba645d59