### PR TITLE
Remove pre-embedding normalization from TimesNet

### DIFF
--- a/tests/test_dummy_training.py
+++ b/tests/test_dummy_training.py
@@ -59,7 +59,6 @@ def test_dummy_training_smape_wsmape():
         "output_proj": model.output_proj,
         "sigma_proj": model.sigma_proj,
         "static_proj": model.static_proj,
-        "pre_embedding_norm": model.pre_embedding_norm,
     }
     if model.series_embedding is not None:
         modules_to_check["series_embedding"] = model.series_embedding


### PR DESCRIPTION
## Summary
- remove the pre-embedding LayerNorm so combined per-series features reach the embedding unchanged
- keep the pre-embedding stage as an identity module that only applies dropout
- verify the behaviour with a new forward-hook regression test and update the dummy training smoke test expectations

## Testing
- pytest tests/test_timesnet_forward.py
- pytest tests/test_dummy_training.py

------
https://chatgpt.com/codex/tasks/task_e_68d3851f59f08328a49631c9d837c2b9