### PR TITLE
Adjust per-series data pipeline, NB loss, and scheduler

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -68,7 +68,7 @@ model:
   d_ff: 1024
   n_layers: 3
   dropout: 0.1
-  k_periods: 3
+  k_periods: 2
   min_period_threshold: 7  # 최소 주기 하한선
   kernel_set:
     - [3, 3]

--- a/src/timesnet_forecast/losses.py
+++ b/src/timesnet_forecast/losses.py
@@ -3,6 +3,23 @@ from __future__ import annotations
 import torch
 
 
+def negative_binomial_mask(
+    y: torch.Tensor,
+    rate: torch.Tensor,
+    dispersion: torch.Tensor,
+    mask: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Compute a boolean mask for valid NB likelihood elements."""
+
+    finite_mask = torch.isfinite(y) & torch.isfinite(rate) & torch.isfinite(dispersion)
+    if mask is not None:
+        mask_bool = mask.to(dtype=torch.bool)
+        if mask_bool.shape != finite_mask.shape:
+            mask_bool = mask_bool.expand_as(finite_mask)
+        finite_mask = finite_mask & mask_bool
+    return finite_mask
+
+
 def negative_binomial_nll(
     y: torch.Tensor,
     rate: torch.Tensor,
@@ -13,26 +30,25 @@ def negative_binomial_nll(
     """Negative binomial negative log-likelihood averaged over valid elements."""
 
     dtype = torch.float32
-    y = y.to(dtype)
+    y = torch.clamp(y.to(dtype), min=0.0)
     rate = rate.to(dtype)
     dispersion = dispersion.to(dtype)
 
     alpha = torch.clamp(dispersion, min=eps)
     mu = torch.clamp(rate, min=eps)
-    r = 1.0 / alpha
-    log_p = torch.log(r) - torch.log(r + mu)
-    log1m_p = torch.log(mu) - torch.log(r + mu)
-    log_prob = (
-        torch.lgamma(y + r)
-        - torch.lgamma(r)
+    log1p_alpha_mu = torch.log1p(alpha * mu)
+    log_alpha = torch.log(alpha)
+    log_mu = torch.log(mu)
+    inv_alpha = torch.reciprocal(alpha)
+    ll = (
+        torch.lgamma(y + inv_alpha)
+        - torch.lgamma(inv_alpha)
         - torch.lgamma(y + 1.0)
-        + r * log_p
-        + y * log1m_p
+        + inv_alpha * (-log1p_alpha_mu)
+        + y * (log_alpha + log_mu - log1p_alpha_mu)
     )
-    if mask is not None:
-        mask = mask.to(dtype)
-        log_prob = log_prob * mask
-        denom = torch.clamp(mask.sum(), min=1.0)
-    else:
-        denom = log_prob.numel()
-    return -(log_prob.sum() / denom)
+
+    valid_mask = negative_binomial_mask(y, mu, alpha, mask)
+    weight = valid_mask.to(dtype)
+    denom = torch.clamp(weight.sum(), min=1.0)
+    return -(ll * weight).sum() / denom

--- a/tests/test_timesnet_forward.py
+++ b/tests/test_timesnet_forward.py
@@ -47,6 +47,29 @@ def test_forward_shape_and_head_processing():
     assert dispersion_long.shape == dispersion_head.shape == (B, H, N)
 
 
+def test_timesnet_blocks_track_period_calls():
+    torch.manual_seed(0)
+    B, L, H, N = 1, 12, 3, 1
+    model = TimesNet(
+        input_len=L,
+        pred_len=H,
+        d_model=8,
+        d_ff=16,
+        n_layers=2,
+        k_periods=2,
+        kernel_set=[(3, 3)],
+        dropout=0.0,
+        activation="gelu",
+        mode="direct",
+    )
+    x = torch.randn(B, L, N)
+    with torch.no_grad():
+        model(x)
+    period_counts = [getattr(block, "_period_calls", 0) for block in model.blocks]
+    assert len(period_counts) == 2
+    assert all(count > 0 for count in period_counts)
+
+
 def test_timesnet_pre_embedding_norm_adapts_to_feature_count():
     torch.manual_seed(0)
     B, L, H, N = 2, 12, 4, 1


### PR DESCRIPTION
## Summary
- make SlidingWindowDataset emit one series per sample and update evaluation utilities to stack outputs per id
- add per-layer period counters, tighten FFT period filtering, and lower the default k_periods to 2
- refactor negative binomial masking/logging and simplify the warmup-to-cosine scheduler handling with safer min_sigma_vector slicing
- optimize per-series window slicing to avoid redundant clones and log the per-epoch sample/batch workload for clarity

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4df402ba88328b5937643c21c75d2