### PR TITLE
Sanitize non-finite history and residual weights before forecasting

### DIFF
--- a/src/timesnet_forecast/models/timesnet.py
+++ b/src/timesnet_forecast/models/timesnet.py
@@ -402,6 +402,10 @@ class TimesBlock(nn.Module):
                 weights_float = F.softmax(amp_for_softmax, dim=1)
             else:
                 weights_float = F.softmax(amp, dim=1)
+            if torch.any(~torch.isfinite(weights_float)):
+                raise RuntimeError(
+                    "TimesNet residual weights contain non-finite values; check input amplitudes"
+                )
             eps = torch.finfo(weights_float.dtype).eps
             weight_sum = weights_float.sum(dim=1, keepdim=True)
             zero_mask = weight_sum <= eps


### PR DESCRIPTION
## Summary
- clone the encoder slice and replace non-finite inputs with zeros before embedding
- raise a clear error if non-floating tensors contain non-finite values
- raise an error when residual weighting produces non-finite softmax outputs

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d52a4ab3e883289a39c726b3154905