### PR TITLE
Fix ID embedding warm-up to cover full identifier range

### DIFF
--- a/src/timesnet_forecast/predict.py
+++ b/src/timesnet_forecast/predict.py
@@ -295,7 +295,9 @@ def predict_once(cfg: Dict) -> str:
         warmup_kwargs["series_static"] = warmup_series_static_single
     warmup_ids_single: torch.Tensor | None = None
     if full_series_ids_tensor.numel() > 0:
-        warmup_ids_single = full_series_ids_tensor[:1]
+        # Mirror training: warm up with the maximum ID to preserve embedding capacity.
+        max_series_id = torch.max(full_series_ids_tensor)
+        warmup_ids_single = max_series_id.reshape(1)
         warmup_kwargs["series_ids"] = warmup_ids_single
     if time_features_enabled and meta_dim > 0:
         warmup_kwargs["x_mark"] = torch.zeros(

--- a/src/timesnet_forecast/train.py
+++ b/src/timesnet_forecast/train.py
@@ -956,7 +956,9 @@ def train_once(cfg: Dict) -> Tuple[float, Dict]:
     # Lazily build model parameters so that downstream utilities see them
     warmup_ids_single: torch.Tensor | None
     if series_ids_default.numel() > 0:
-        warmup_ids_single = series_ids_default[:1]
+        # Use the maximum identifier so the embedding initializes capacity for all IDs.
+        max_series_id = torch.max(series_ids_default)
+        warmup_ids_single = max_series_id.reshape(1)
     else:
         warmup_ids_single = None
     warmup_kwargs = {


### PR DESCRIPTION
## Summary
- warm up the training pass with the maximum series identifier so the embedding table is sized for every ID
- mirror the same warm-up behaviour in predict.py and explain the intent with inline comments

## Testing
- python -m src.timesnet_forecast.train --config configs/default.yaml --override train.device=cpu train.num_workers=1 train.pin_memory=False train.persistent_workers=False train.epochs=0 train.lr_warmup_steps=0

------
https://chatgpt.com/codex/tasks/task_e_68d8e01215dc832889f2c21bf1da4d89