### PR TITLE
Add schema detection and validation for training and inference

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -9,6 +9,8 @@ data:
   horizon: 7
   fill_missing_dates: true
   encoding: "utf-8-sig"
+  schema_detection_policy: "infer"
+  schema_evolution_policy: "warn"
   augment:
     add_noise_std: 0.005       # 표준편차; 0이면 사용 안 함
     time_shift: 2            # 입력 시퀀스 시작 위치 랜덤 시프트 범위

--- a/tests/test_global_pmax.py
+++ b/tests/test_global_pmax.py
@@ -97,8 +97,8 @@ def test_train_once_runs_without_pmax(tmp_path):
     ]
     cfg = Config.from_files("configs/default.yaml", overrides=overrides).to_dict()
 
-    schema = io_utils.resolve_schema(cfg)
     df_loaded = pd.read_csv(csv_path)
+    schema = io_utils.DataSchema.from_config(cfg["data"], sample_df=df_loaded)
     wide = io_utils.pivot_long_to_wide(
         df_loaded,
         date_col=schema["date"],

--- a/tests/test_schema_policies.py
+++ b/tests/test_schema_policies.py
@@ -1,0 +1,87 @@
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+# Ensure the project src is on the path for imports
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from timesnet_forecast.utils import io as io_utils
+
+
+def _build_ambiguous_dataframe() -> pd.DataFrame:
+    dates = pd.date_range("2024-01-01", periods=4, freq="D")
+    return pd.DataFrame(
+        {
+            "주문일자": dates,
+            "배송시작일": dates + pd.Timedelta(days=1),
+            "영업장명_메뉴명": ["StoreA_Menu1"] * len(dates),
+            "매출수량": [1.0, 2.0, 3.0, 4.0],
+        }
+    )
+
+
+def _build_evolving_dataframe() -> pd.DataFrame:
+    dates = pd.date_range("2024-01-01", periods=6, freq="D")
+    rows = []
+    for idx, d in enumerate(dates):
+        rows.append(
+            {
+                "date": d,
+                "id": "StoreA",
+                "target": float(idx + 1),
+                "promo_type": None if idx < 3 else "BUNDLE",
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def test_schema_detection_strict_rejects_ambiguity():
+    df = _build_ambiguous_dataframe()
+    with pytest.raises(ValueError) as exc:
+        io_utils.DataSchema.from_config(
+            {"schema_detection_policy": "strict"},
+            sample_df=df,
+        )
+    assert "Ambiguous auto-detection" in str(exc.value)
+
+
+def test_schema_detection_manual_requires_overrides():
+    df = _build_ambiguous_dataframe()
+    with pytest.raises(ValueError):
+        io_utils.DataSchema.from_config(
+            {"schema_detection_policy": "manual"},
+            sample_df=df,
+        )
+
+    schema = io_utils.DataSchema.from_config(
+        {
+            "schema_detection_policy": "manual",
+            "date_col": "주문일자",
+            "id_col": "영업장명_메뉴명",
+            "target_col": "매출수량",
+        },
+        sample_df=df,
+    )
+    assert schema["date"] == "주문일자"
+    assert schema.sources["date"] == "override"
+
+
+def test_schema_evolution_warns(caplog):
+    df = _build_evolving_dataframe()
+    caplog.set_level("WARNING")
+    schema = io_utils.DataSchema.from_config({}, sample_df=df)
+    assert any("Schema evolution detected" in rec.message for rec in caplog.records)
+    coverage = schema.detection.get("coverage", {})
+    promo_meta = coverage.get("promo_type")
+    assert promo_meta and promo_meta.get("missing_prefix") is True
+
+
+def test_schema_evolution_error_policy():
+    df = _build_evolving_dataframe()
+    with pytest.raises(ValueError):
+        io_utils.DataSchema.from_config(
+            {"schema_evolution_policy": "error"},
+            sample_df=df,
+        )


### PR DESCRIPTION
## Summary
- introduce a DataSchema abstraction with automatic column detection and artifact serialization metadata
- refactor training to resolve schemas from data, persist normalization metadata, and reuse the new artifact writer
- align prediction and tests with the schema abstraction while covering manual and auto schema scenarios

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d9e7b411188328a0fe982cbb54c69a