### PR TITLE
Add low-rank context configuration options

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -82,6 +82,10 @@ model:
   id_embed_dim: 32           # Per-series identifier embedding dimension (set to 0 to disable)
   static_proj_dim: 32        # Projection size for static covariates (set to null to keep input dim)
   static_layernorm: true     # Apply LayerNorm after projecting static covariates
+  use_zero_mean_context: true
+  context_rank: 8
+  context_scale: 0.05
+  use_constant_context_bias: true
 
 tuning:
   enabled: true

--- a/src/timesnet_forecast/train.py
+++ b/src/timesnet_forecast/train.py
@@ -965,6 +965,17 @@ def train_once(cfg: PipelineConfig | Dict[str, Any]) -> Tuple[float, Dict]:
     model_cfg["static_proj_dim"] = static_proj_dim
     model_cfg["static_layernorm"] = static_layernorm
 
+    use_zero_mean_context = bool(model_cfg.get("use_zero_mean_context", False))
+    context_rank = int(model_cfg.get("context_rank", 0))
+    if context_rank < 0:
+        context_rank = 0
+    context_scale = float(model_cfg.get("context_scale", 1e-2))
+    use_constant_context_bias = bool(model_cfg.get("use_constant_context_bias", False))
+    model_cfg["use_zero_mean_context"] = use_zero_mean_context
+    model_cfg["context_rank"] = context_rank
+    model_cfg["context_scale"] = context_scale
+    model_cfg["use_constant_context_bias"] = use_constant_context_bias
+
     model = TimesNet(
         input_len=input_len,
         pred_len=pred_len,
@@ -986,6 +997,10 @@ def train_once(cfg: PipelineConfig | Dict[str, Any]) -> Tuple[float, Dict]:
         id_embed_dim=id_embed_dim,
         static_proj_dim=static_proj_dim,
         static_layernorm=static_layernorm,
+        use_zero_mean_context=use_zero_mean_context,
+        context_rank=context_rank,
+        context_scale=context_scale,
+        use_constant_context_bias=use_constant_context_bias,
     ).to(device)
 
     # Lazily build model parameters so that downstream utilities see them


### PR DESCRIPTION
## Summary
- expose low-rank temporal context options in the default model configuration
- propagate the new context settings through training with safe defaults for backwards compatibility

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db6eb87b688328a95a9dc75b2a75e1